### PR TITLE
fix(protocol): handle non-UTF-8 in Obsidian vault

### DIFF
--- a/crates/miyabi-core/src/protocol.rs
+++ b/crates/miyabi-core/src/protocol.rs
@@ -1211,7 +1211,13 @@ fn read_file_snippet(path: &Path, max_lines: usize) -> Result<String, Error> {
     let reader = BufReader::new(file);
     let mut lines = Vec::new();
     for line in reader.lines().take(max_lines) {
-        lines.push(line?);
+        match line {
+            Ok(l) => lines.push(l),
+            Err(_) => {
+                // Non-UTF-8 file (binary) — return what we have so far
+                break;
+            }
+        }
     }
     Ok(lines.join("\n"))
 }


### PR DESCRIPTION
## Summary
- Gracefully handle non-UTF-8 bytes in read_file_snippet instead of hard error
- Tested with real Obsidian vault (HAYASHI-Knowledge) — 2 notes successfully attached
- Also includes depth-1 impact attach from PR #90

## Test plan
- [x] `cargo test --all` passes (926 tests)
- [x] Real Obsidian vault test: OBSIDIAN_VAULT_PATH set, notes attached
- [x] Polaris gate workflow followed

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)