### PR TITLE
feat(gate): add validation and dashboard insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ mergegate gate stats --format json
 mergegate gate serve
 ```
 
+`mergegate gate serve` opens the MergeGate-native web surface for:
+
+- Gate Overview: validation severity, operator next actions, ready and attention queues
+- Task Ledger: filterable state/risk/since views plus task detail drill-in
+- Dependency Map: DAG levels, blocked chain visibility, and dispatchable frontier
+
+Static asset loading follows this order:
+
+1. `MERGEGATE_DASHBOARD_STATIC_DIR`
+2. `web/dashboard/dist`
+3. embedded Rust-owned dashboard fallback
+
 Compatibility alias:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MergeGate
 
+[![CI](https://github.com/ShunsukeHayashi/mergegate/actions/workflows/ci.yml/badge.svg)](https://github.com/ShunsukeHayashi/mergegate/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Rust](https://img.shields.io/badge/Rust-1.75%2B-orange.svg)](https://www.rust-lang.org/)
+
 MergeGate is an engine-agnostic gate CLI for AI-assisted development.
 
 It does not need to be your coding agent, your chat runtime, or your terminal UI. Its job is simpler and more durable:
@@ -111,7 +115,15 @@ This creates `project_memory/tasks.json`.
 ./target/release/mergegate gate guide
 ```
 
-### 4. Start a task
+### 4. Audit the ledger
+
+```bash
+./target/release/mergegate gate validate
+./target/release/mergegate gate export-json --state implementing
+./target/release/mergegate gate stats --format json
+```
+
+### 5. Start a task
 
 ```bash
 ./target/release/mergegate gate register --issue 123 --title "Fix login redirect"
@@ -141,6 +153,10 @@ mergegate gate assign issue-123 --agent codex --node macbook --files "src/auth.r
 mergegate gate branch issue-123 codex/fix-login-redirect
 mergegate gate pr issue-123 456
 mergegate gate merge issue-123 <sha>
+mergegate gate validate
+mergegate gate export-json --state implementing
+mergegate gate export-md --risk HIGH
+mergegate gate stats --format json
 ```
 
 Compatibility alias:
@@ -162,9 +178,14 @@ mergegate gate branch issue-123 codex/fix-login-redirect
 mergegate gate pr issue-123 456
 mergegate gate merge issue-123 <sha>
 mergegate gate manual-complete issue-123 --reason "docs-only change" --operator shunsuke
+mergegate gate validate
+mergegate gate export-json --state implementing
+mergegate gate export-md --since 2026-04-12
+mergegate gate stats --format json
 mergegate gate locks
 mergegate gate dispatchable
 mergegate gate dag
+mergegate gate serve
 ```
 
 ## Product Direction
@@ -200,6 +221,11 @@ That is not an error. It means the ledger exists but no tasks have been register
 
 That is usually safe. It means `project_memory/tasks.json` already exists.
 
+### `gate validate` returns exit code `1` or `2`
+
+`1` means warnings only. `2` means a real consistency problem such as orphaned locks,
+invalid transitions, or circular dependencies.
+
 ### I want to use another coding agent
 
 That is the intended model. MergeGate is the gate, not the engine.
@@ -217,4 +243,3 @@ Planning to introduce AI coding agents to your team? We wrote a practical guide 
 **[Download the guide (PDF)](https://miyabi-assets.pages.dev/assets/ai-dev-team-guide.pdf)** — free, no signup required.
 
 Want a walkthrough customized to your team? **[Chat with us on LINE](https://miyabi-line-crm.supernovasyun.workers.dev/auth/line?ref=b2b-github)** for a free 30-min consultation.
-

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ This creates `project_memory/tasks.json`.
 
 ```bash
 ./target/release/mergegate gate validate
-./target/release/mergegate gate export-json --state implementing
+./target/release/mergegate gate --format json validate
+./target/release/mergegate gate export-json --state implementing --risk HIGH --since 2026-04-12
+./target/release/mergegate gate export-md --state implementing --risk HIGH --since 2026-04-12
 ./target/release/mergegate gate stats --format json
 ```
 
@@ -154,9 +156,11 @@ mergegate gate branch issue-123 codex/fix-login-redirect
 mergegate gate pr issue-123 456
 mergegate gate merge issue-123 <sha>
 mergegate gate validate
-mergegate gate export-json --state implementing
-mergegate gate export-md --risk HIGH
+mergegate gate --format json validate
+mergegate gate export-json --state implementing --risk HIGH --since 2026-04-12
+mergegate gate export-md --state implementing --risk HIGH --since 2026-04-12
 mergegate gate stats --format json
+mergegate gate serve
 ```
 
 Compatibility alias:
@@ -179,8 +183,9 @@ mergegate gate pr issue-123 456
 mergegate gate merge issue-123 <sha>
 mergegate gate manual-complete issue-123 --reason "docs-only change" --operator shunsuke
 mergegate gate validate
-mergegate gate export-json --state implementing
-mergegate gate export-md --since 2026-04-12
+mergegate gate --format json validate
+mergegate gate export-json --state implementing --risk HIGH --since 2026-04-12
+mergegate gate export-md --state implementing --risk HIGH --since 2026-04-12
 mergegate gate stats --format json
 mergegate gate locks
 mergegate gate dispatchable
@@ -197,6 +202,16 @@ MergeGate is intentionally moving away from:
 - vendor-specific backend identity
 
 The durable surface is the gate CLI.
+
+The mainline product direction is:
+
+- Rust-first deterministic execution protocol
+- CLI/API as the source of truth
+- MergeGate-native UI as a supporting surface
+- no multi-source PM dashboard positioning in the core product
+
+PM dashboard assets may inform MergeGate UI/UX, but cross-source orchestration remains a separate higher-level layer.
+See [docs/PRODUCT_DIRECTION.md](/Users/shunsukehayashi/dev/personal/HAYASHI_SHUNSUKE/mergegate/docs/PRODUCT_DIRECTION.md).
 
 ## Workspace Layout
 

--- a/crates/mergegate-cli/src/dashboard_embedded.html
+++ b/crates/mergegate-cli/src/dashboard_embedded.html
@@ -1,0 +1,1400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MergeGate Dashboard</title>
+  <style>
+    :root {
+      --bg: #07111f;
+      --panel: rgba(10, 24, 42, 0.88);
+      --panel-strong: rgba(13, 31, 53, 0.98);
+      --border: rgba(123, 164, 208, 0.18);
+      --text: #eaf4ff;
+      --muted: #8ca5c1;
+      --accent: #4ecdc4;
+      --accent-2: #ffd166;
+      --danger: #ff6b6b;
+      --warning: #f7b267;
+      --ok: #95d5b2;
+      --shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+      --radius: 22px;
+      --radius-sm: 14px;
+      --font: "IBM Plex Sans", "Avenir Next", sans-serif;
+      --mono: "IBM Plex Mono", "SFMono-Regular", monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: var(--font);
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(78, 205, 196, 0.2), transparent 24rem),
+        radial-gradient(circle at top right, rgba(255, 209, 102, 0.2), transparent 22rem),
+        linear-gradient(160deg, #06111f 0%, #09182c 48%, #0e223b 100%);
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .shell {
+      width: min(1380px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 24px 0 40px;
+    }
+
+    .masthead {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: 1.4fr minmax(280px, 0.9fr);
+      align-items: stretch;
+    }
+
+    .hero,
+    .meta-card,
+    .panel,
+    .ledger-detail,
+    .level-card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(18px);
+    }
+
+    .hero {
+      padding: 28px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: auto -6rem -8rem auto;
+      width: 18rem;
+      height: 18rem;
+      background: radial-gradient(circle, rgba(78, 205, 196, 0.22), transparent 68%);
+      pointer-events: none;
+    }
+
+    .eyebrow,
+    .section-eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.73rem;
+      color: var(--muted);
+      margin-bottom: 10px;
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      margin: 0;
+    }
+
+    .hero-title {
+      font-size: clamp(2rem, 4vw, 3.5rem);
+      line-height: 1.02;
+      max-width: 11ch;
+    }
+
+    .hero-copy {
+      margin-top: 12px;
+      max-width: 54ch;
+      color: rgba(234, 244, 255, 0.78);
+      line-height: 1.6;
+    }
+
+    .hero-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin-top: 22px;
+      padding: 11px 16px;
+      border-radius: 999px;
+      font-weight: 700;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .hero-status.clean {
+      color: var(--ok);
+      background: rgba(149, 213, 178, 0.12);
+    }
+
+    .hero-status.warning {
+      color: var(--warning);
+      background: rgba(247, 178, 103, 0.13);
+    }
+
+    .hero-status.error {
+      color: #ffd0d0;
+      background: rgba(255, 107, 107, 0.13);
+    }
+
+    .meta-card {
+      padding: 22px;
+      display: grid;
+      gap: 18px;
+      align-content: start;
+    }
+
+    .meta-top {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+    }
+
+    .meta-title {
+      font-size: 1.05rem;
+      font-weight: 700;
+    }
+
+    .meta-body {
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+
+    .metric-grid {
+      margin-top: 18px;
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .metric {
+      padding: 18px;
+      border-radius: var(--radius-sm);
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.84rem;
+      margin-bottom: 8px;
+    }
+
+    .metric-value {
+      font-size: clamp(1.6rem, 2.5vw, 2.4rem);
+      font-weight: 700;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 10px;
+      margin: 22px 0 18px;
+      flex-wrap: wrap;
+    }
+
+    .tab {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 999px;
+      padding: 10px 16px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 120ms ease, border-color 120ms ease, color 120ms ease, background 120ms ease;
+    }
+
+    .tab:hover {
+      transform: translateY(-1px);
+      border-color: rgba(78, 205, 196, 0.5);
+      color: var(--text);
+    }
+
+    .tab.active {
+      background: rgba(78, 205, 196, 0.14);
+      border-color: rgba(78, 205, 196, 0.55);
+      color: var(--text);
+    }
+
+    .view {
+      display: none;
+      animation: fade-in 220ms ease;
+    }
+
+    .view.active {
+      display: block;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .overview-grid,
+    .ledger-grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .overview-grid {
+      grid-template-columns: 1.2fr 1fr;
+    }
+
+    .panel {
+      padding: 20px;
+    }
+
+    .panel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+
+    .panel-title {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .pill-row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 16px;
+    }
+
+    .pill,
+    .tiny-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      font-size: 0.83rem;
+      padding: 7px 10px;
+      background: rgba(255, 255, 255, 0.05);
+      color: var(--muted);
+    }
+
+    .tiny-pill {
+      padding: 5px 9px;
+      font-size: 0.76rem;
+    }
+
+    .list,
+    .detail-list,
+    .dag-levels {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 10px;
+    }
+
+    .task-item,
+    .detail-item,
+    .action-item,
+    .node-card {
+      border-radius: 16px;
+      padding: 14px;
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .action-item {
+      display: grid;
+      gap: 8px;
+    }
+
+    .task-item.clickable,
+    .node-card.clickable {
+      cursor: pointer;
+      transition: border-color 120ms ease, transform 120ms ease, background 120ms ease;
+    }
+
+    .task-item.clickable:hover,
+    .node-card.clickable:hover {
+      transform: translateY(-1px);
+      border-color: rgba(78, 205, 196, 0.4);
+      background: rgba(78, 205, 196, 0.06);
+    }
+
+    .task-item.selected,
+    .node-card.selected {
+      border-color: rgba(78, 205, 196, 0.65);
+      background: rgba(78, 205, 196, 0.1);
+    }
+
+    .task-top,
+    .node-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .task-title,
+    .node-title {
+      font-weight: 700;
+      line-height: 1.4;
+    }
+
+    .task-id,
+    .mono,
+    .list-meta,
+    .meta-inline {
+      font-family: var(--mono);
+    }
+
+    .task-id,
+    .list-meta,
+    .task-meta,
+    .meta-inline,
+    .subtle {
+      font-size: 0.83rem;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    .badge {
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text);
+      background: rgba(255, 255, 255, 0.08);
+      white-space: nowrap;
+    }
+
+    .badge.pending,
+    .badge.dispatchable {
+      background: rgba(78, 205, 196, 0.15);
+      color: #b8fff4;
+    }
+
+    .badge.blocked,
+    .badge.failed,
+    .badge.error {
+      background: rgba(255, 107, 107, 0.18);
+      color: #ffd8d8;
+    }
+
+    .badge.implementing,
+    .badge.reviewing,
+    .badge.analyzing,
+    .badge.deploying {
+      background: rgba(255, 209, 102, 0.18);
+      color: #fff0b5;
+    }
+
+    .badge.done,
+    .badge.merged,
+    .badge.clean {
+      background: rgba(149, 213, 178, 0.17);
+      color: #d8ffeb;
+    }
+
+    .action-label {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+    }
+
+    .action-label.error {
+      color: #ffb8b8;
+    }
+
+    .action-label.warning {
+      color: #ffe0a3;
+    }
+
+    .action-label.info {
+      color: #b8fff4;
+    }
+
+    .empty {
+      color: var(--muted);
+      padding: 12px 0;
+    }
+
+    .ledger-grid {
+      grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+      align-items: start;
+    }
+
+    .filter-bar {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(3, minmax(0, 1fr)) auto auto;
+      margin-bottom: 16px;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    select,
+    input,
+    button {
+      font: inherit;
+    }
+
+    select,
+    input[type="date"] {
+      width: 100%;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(4, 12, 22, 0.7);
+      color: var(--text);
+    }
+
+    .button {
+      align-self: end;
+      border: none;
+      padding: 10px 14px;
+      border-radius: 12px;
+      font-weight: 700;
+      cursor: pointer;
+      background: rgba(78, 205, 196, 0.16);
+      color: var(--text);
+    }
+
+    .button.secondary {
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--muted);
+    }
+
+    .ledger-list {
+      max-height: 62vh;
+      overflow: auto;
+      padding-right: 4px;
+    }
+
+    .ledger-detail {
+      padding: 22px;
+      position: sticky;
+      top: 18px;
+    }
+
+    .detail-grid {
+      display: grid;
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .detail-block {
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      padding: 14px;
+    }
+
+    .detail-label {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      margin-bottom: 8px;
+    }
+
+    .detail-value {
+      line-height: 1.6;
+      word-break: break-word;
+    }
+
+    .dependency-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .dependency-summary {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      margin-bottom: 18px;
+    }
+
+    .dag-board {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    }
+
+    .level-card {
+      padding: 18px;
+    }
+
+    .level-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      align-items: baseline;
+      margin-bottom: 12px;
+    }
+
+    .level-title {
+      font-weight: 700;
+    }
+
+    .level-count {
+      color: var(--muted);
+      font-size: 0.82rem;
+    }
+
+    .node-grid {
+      display: grid;
+      gap: 10px;
+    }
+
+    .node-pressure {
+      margin-top: 10px;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .footer-note {
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    @media (max-width: 1080px) {
+      .masthead,
+      .overview-grid,
+      .ledger-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .metric-grid,
+      .dependency-summary,
+      .filter-bar {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .ledger-detail {
+        position: static;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .shell {
+        width: min(100vw - 20px, 100%);
+        padding-top: 14px;
+      }
+
+      .hero,
+      .meta-card,
+      .panel,
+      .ledger-detail,
+      .level-card {
+        border-radius: 18px;
+      }
+
+      .metric-grid,
+      .dependency-summary,
+      .filter-bar {
+        grid-template-columns: 1fr;
+      }
+
+      .task-top,
+      .node-top,
+      .panel-header {
+        flex-direction: column;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <section class="masthead">
+      <div class="hero">
+        <div class="eyebrow">MergeGate UI Mainline</div>
+        <h1 class="hero-title">Gate Overview, Ledger, and Dependency Map</h1>
+        <p class="hero-copy">
+          Rust-owned protocol data stays the source of truth. This dashboard highlights what is dispatchable,
+          what needs operator attention, and how the dependency frontier is moving.
+        </p>
+        <div id="hero-status" class="hero-status clean">Healthy</div>
+        <div class="metric-grid">
+          <div class="metric">
+            <div class="metric-label">Dispatchable</div>
+            <div id="metric-dispatchable" class="metric-value">0</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Validation Issues</div>
+            <div id="metric-issues" class="metric-value">0</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Active Locks</div>
+            <div id="metric-locks" class="metric-value">0</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Completion</div>
+            <div id="metric-completion" class="metric-value">0%</div>
+          </div>
+        </div>
+      </div>
+      <aside class="meta-card">
+        <div class="meta-top">
+          <div>
+            <div class="eyebrow">Operator Meta</div>
+            <div class="meta-title">Ledger Health</div>
+          </div>
+          <span id="severity-pill" class="tiny-pill">clean</span>
+        </div>
+        <div id="health-summary" class="meta-body">Loading dashboard state...</div>
+        <div id="health-pills" class="pill-row"></div>
+        <div class="detail-block">
+          <div class="detail-label">Snapshot</div>
+          <div id="meta" class="detail-value subtle">Waiting for the first refresh.</div>
+        </div>
+      </aside>
+    </section>
+
+    <nav class="tabs" aria-label="Dashboard sections">
+      <button class="tab active" data-view="overview">Gate Overview</button>
+      <button class="tab" data-view="ledger">Task Ledger</button>
+      <button class="tab" data-view="dependency">Dependency Map</button>
+    </nav>
+
+    <main>
+      <section id="view-overview" class="view active">
+        <div class="overview-grid">
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">First Response</div>
+                <div class="panel-title">Next Actions</div>
+              </div>
+            </div>
+            <ul id="next-actions" class="list"></ul>
+          </div>
+
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Ledger Safety</div>
+                <div class="panel-title">Validation Detail</div>
+              </div>
+            </div>
+            <ul id="validation-detail" class="detail-list"></ul>
+          </div>
+
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Dispatchable First</div>
+                <div class="panel-title">Ready Queue</div>
+              </div>
+              <span id="ready-count" class="tiny-pill">0 tasks</span>
+            </div>
+            <ul id="queue-ready" class="list"></ul>
+          </div>
+
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Attention</div>
+                <div class="panel-title">Blocked / Failed / Awaiting Sync</div>
+              </div>
+              <span id="attention-count" class="tiny-pill">0 tasks</span>
+            </div>
+            <ul id="queue-attention" class="list"></ul>
+          </div>
+
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Work In Motion</div>
+                <div class="panel-title">Progress Queue</div>
+              </div>
+              <span id="progress-count" class="tiny-pill">0 tasks</span>
+            </div>
+            <ul id="queue-progress" class="list"></ul>
+          </div>
+
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Lock Surface</div>
+                <div class="panel-title">Active Locks</div>
+              </div>
+              <span id="locks-count" class="tiny-pill">0 locks</span>
+            </div>
+            <ul id="locks" class="list"></ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="view-ledger" class="view">
+        <div class="ledger-grid">
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Task Ledger</div>
+                <div class="panel-title">Filterable MergeGate-native tasks</div>
+              </div>
+              <span id="ledger-count" class="tiny-pill">0 tasks</span>
+            </div>
+            <form id="ledger-filters" class="filter-bar">
+              <label>
+                State
+                <select id="filter-state" name="state">
+                  <option value="">All states</option>
+                  <option value="draft">draft</option>
+                  <option value="pending">pending</option>
+                  <option value="analyzing">analyzing</option>
+                  <option value="implementing">implementing</option>
+                  <option value="reviewing">reviewing</option>
+                  <option value="awaiting_github_sync">awaiting_github_sync</option>
+                  <option value="merged">merged</option>
+                  <option value="done">done</option>
+                  <option value="blocked">blocked</option>
+                  <option value="failed">failed</option>
+                </select>
+              </label>
+              <label>
+                Risk
+                <select id="filter-risk" name="risk">
+                  <option value="">All risk levels</option>
+                  <option value="LOW">LOW</option>
+                  <option value="MEDIUM">MEDIUM</option>
+                  <option value="HIGH">HIGH</option>
+                  <option value="CRITICAL">CRITICAL</option>
+                </select>
+              </label>
+              <label>
+                Since
+                <input id="filter-since" name="since" type="date">
+              </label>
+              <button type="submit" class="button">Apply</button>
+              <button id="filters-reset" type="button" class="button secondary">Reset</button>
+            </form>
+            <div id="ledger-results" class="ledger-list"></div>
+          </div>
+
+          <aside class="ledger-detail">
+            <div class="section-eyebrow">Task Detail</div>
+            <h2 id="detail-title">Select a task</h2>
+            <p id="detail-summary" class="meta-body" style="margin-top: 10px;">
+              Pick a task from the ledger, overview queues, or dependency map to inspect branch, dependencies,
+              evidence, and completion mode.
+            </p>
+            <div id="detail-grid" class="detail-grid"></div>
+          </aside>
+        </div>
+      </section>
+
+      <section id="view-dependency" class="view">
+        <div class="dependency-grid">
+          <div class="panel">
+            <div class="panel-header">
+              <div>
+                <div class="section-eyebrow">Dependency Pressure</div>
+                <div class="panel-title">Frontier, blocked chain, and level structure</div>
+              </div>
+            </div>
+            <div class="dependency-summary">
+              <div class="metric">
+                <div class="metric-label">Dispatchable Frontier</div>
+                <div id="frontier-count" class="metric-value">0</div>
+              </div>
+              <div class="metric">
+                <div class="metric-label">Blocked Tasks</div>
+                <div id="blocked-count" class="metric-value">0</div>
+              </div>
+              <div class="metric">
+                <div class="metric-label">Dependency Levels</div>
+                <div id="level-count" class="metric-value">0</div>
+              </div>
+            </div>
+            <div id="dependency-frontier" class="pill-row"></div>
+            <p id="dependency-summary-text" class="footer-note">Loading dependency data...</p>
+          </div>
+
+          <div class="dag-board" id="dag-board"></div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const ACTIVE_STATES = new Set(["analyzing", "implementing", "reviewing", "deploying"]);
+    const ATTENTION_STATES = new Set(["blocked", "failed", "awaiting_github_sync"]);
+
+    const state = {
+      currentView: "overview",
+      selectedTaskId: null,
+      allTasksPayload: { tasks: [] },
+      filteredTasksPayload: { tasks: [] },
+      stats: {},
+      validation: {},
+      locks: {},
+      dag: { levels: [] },
+      dispatchable: { task_ids: [], tasks: [] }
+    };
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    function badgeClass(stateName) {
+      return "badge " + (stateName || "unknown");
+    }
+
+    function setListEmpty(id, message) {
+      document.getElementById(id).innerHTML = '<div class="empty">' + escapeHtml(message) + '</div>';
+    }
+
+    function setElementHtml(id, html) {
+      document.getElementById(id).innerHTML = html;
+    }
+
+    function queryParams() {
+      return new URLSearchParams(window.location.search);
+    }
+
+    function currentFilterQuery() {
+      const params = queryParams();
+      const filter = new URLSearchParams();
+      ["state", "risk", "since"].forEach(key => {
+        const value = params.get(key);
+        if (value) filter.set(key, value);
+      });
+      const text = filter.toString();
+      return text ? "?" + text : "";
+    }
+
+    function currentView() {
+      const queryView = queryParams().get("view");
+      if (queryView) return queryView;
+
+      const path = window.location.pathname.replace(/\/+$/, "") || "/";
+      if (path === "/ledger") return "ledger";
+      if (path === "/dependency") return "dependency";
+      return "overview";
+    }
+
+    function applyUiStateToUrl(next) {
+      const params = queryParams();
+      Object.entries(next).forEach(([key, value]) => {
+        if (value === null || value === undefined || value === "") {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      });
+      const nextUrl = window.location.pathname + (params.toString() ? "?" + params.toString() : "");
+      window.history.replaceState({}, "", nextUrl);
+    }
+
+    function switchView(viewName) {
+      state.currentView = viewName;
+      document.querySelectorAll(".tab").forEach(button => {
+        button.classList.toggle("active", button.dataset.view === viewName);
+      });
+      document.querySelectorAll(".view").forEach(view => {
+        view.classList.toggle("active", view.id === "view-" + viewName);
+      });
+      applyUiStateToUrl({ view: viewName });
+    }
+
+    function selectTask(taskId, targetView) {
+      state.selectedTaskId = taskId;
+      if (targetView) switchView(targetView);
+      renderLedgerList();
+      renderDag(state.dag, state.allTasksPayload.tasks);
+      renderTaskDetail();
+    }
+
+    function validationIssueCount(report) {
+      return (
+        (report.orphaned_locks || []).length +
+        (report.invalid_transitions || []).length +
+        (report.circular_dependencies || []).length +
+        (report.warnings || []).length
+      );
+    }
+
+    function stateCount(tasks, predicate) {
+      return tasks.filter(predicate).length;
+    }
+
+    function humanTaskMeta(task) {
+      const deps = Array.isArray(task.dependencies) && task.dependencies.length > 0
+        ? task.dependencies.join(", ")
+        : "none";
+      const risk = task.impact_risk || "n/a";
+      return "priority " + task.priority + " | risk " + risk + " | deps " + deps;
+    }
+
+    function renderTaskCards(tasks, emptyMessage, options = {}) {
+      if (!Array.isArray(tasks) || tasks.length === 0) {
+        return '<div class="empty">' + escapeHtml(emptyMessage) + '</div>';
+      }
+
+      return tasks.map(task => {
+        const selected = task.id === state.selectedTaskId ? " selected" : "";
+        const clickable = options.clickable === false ? "" : " clickable";
+        return (
+          '<div class="task-item' + clickable + selected + '" data-task-id="' + escapeHtml(task.id) + '">' +
+            '<div class="task-top">' +
+              '<div>' +
+                '<div class="task-title">' + escapeHtml(task.title) + '</div>' +
+                '<div class="task-id subtle">' + escapeHtml(task.id) + '</div>' +
+              '</div>' +
+              '<span class="' + badgeClass(task.current_state || "unknown") + '">' +
+                escapeHtml(task.current_state || "unknown") +
+              '</span>' +
+            '</div>' +
+            '<div class="task-meta">' + escapeHtml(humanTaskMeta(task)) + '</div>' +
+          '</div>'
+        );
+      }).join("");
+    }
+
+    function renderHealth(tasks, stats, validation, locks, dispatchable) {
+      const issueCount = validationIssueCount(validation);
+      const severity = validation.severity || "clean";
+      const dispatchableCount = dispatchable.count || 0;
+      const heroStatus = severity === "error"
+        ? "Action Needed"
+        : severity === "warning"
+          ? "Review Needed"
+          : dispatchableCount > 0
+            ? "Ready To Move"
+            : "Healthy";
+
+      const hero = document.getElementById("hero-status");
+      hero.className = "hero-status " + severity;
+      hero.textContent = heroStatus + " · " + issueCount + " issue(s)";
+      document.getElementById("severity-pill").textContent = severity;
+      document.getElementById("severity-pill").className = "tiny-pill " + severity;
+      document.getElementById("metric-dispatchable").textContent = String(dispatchableCount);
+      document.getElementById("metric-issues").textContent = String(issueCount);
+      document.getElementById("metric-locks").textContent = String(Object.keys(locks || {}).length);
+      document.getElementById("metric-completion").textContent = Math.round(stats.completion_rate_pct || 0) + "%";
+
+      const blockedCount = stateCount(tasks, task => task.current_state === "blocked");
+      const activeCount = stateCount(tasks, task => ACTIVE_STATES.has(task.current_state));
+      const summaryParts = [];
+      if (severity === "error") {
+        summaryParts.push("Validation reports ledger errors, so fix consistency before dispatching new work.");
+      } else if (severity === "warning") {
+        summaryParts.push("Warnings exist. The ledger is usable, but it is worth reviewing before dispatch.");
+      } else {
+        summaryParts.push("Ledger consistency is clean.");
+      }
+      summaryParts.push(dispatchableCount > 0
+        ? dispatchableCount + " dispatchable task(s) are ready now."
+        : "No dispatchable tasks are waiting right now.");
+      summaryParts.push(activeCount > 0
+        ? activeCount + " task(s) are currently in motion."
+        : "No active tasks are running.");
+      summaryParts.push(blockedCount > 0
+        ? blockedCount + " blocked task(s) need dependency or review follow-up."
+        : "No blocked tasks are currently recorded.");
+      document.getElementById("health-summary").textContent = summaryParts.join(" ");
+
+      const pills = [
+        (stats.completed || 0) + " completed",
+        (stats.active || 0) + " active",
+        (stats.waiting || 0) + " waiting",
+        (stats.failed || 0) + " failed",
+        (Object.keys(locks || {}).length) + " locks"
+      ];
+      document.getElementById("health-pills").innerHTML =
+        pills.map(label => '<span class="pill">' + escapeHtml(label) + '</span>').join("");
+    }
+
+    function renderNextActions(tasks, validation, dispatchable) {
+      const actions = [];
+      if ((validation.invalid_transitions || []).length > 0 || (validation.orphaned_locks || []).length > 0) {
+        actions.push({
+          kind: "error",
+          title: "Fix ledger consistency first",
+          body: "Run mergegate gate validate, then resolve lock ownership or invalid state transitions before dispatch."
+        });
+      }
+
+      if ((dispatchable.task_ids || []).length > 0) {
+        actions.push({
+          kind: "info",
+          title: "Dispatch from the frontier",
+          body: (dispatchable.task_ids || []).slice(0, 3).join(", ")
+        });
+      }
+
+      const blocked = tasks.filter(task => task.current_state === "blocked");
+      if (blocked.length > 0) {
+        actions.push({
+          kind: "warning",
+          title: "Unblock dependent work",
+          body: blocked.slice(0, 3).map(task => task.id + " waits on " + ((task.dependencies || []).join(", ") || "follow-up")).join(" | ")
+        });
+      }
+
+      const awaitingReview = tasks.filter(task => task.current_state === "reviewing");
+      if (awaitingReview.length > 0) {
+        actions.push({
+          kind: "info",
+          title: "Review in-flight work",
+          body: awaitingReview.slice(0, 3).map(task => task.id).join(", ")
+        });
+      }
+
+      if (actions.length === 0) {
+        actions.push({
+          kind: "info",
+          title: "No urgent operator action",
+          body: "The ledger looks stable. Review progress or wait for the next task to become dispatchable."
+        });
+      }
+
+      setElementHtml("next-actions", actions.map(action => (
+        '<div class="action-item">' +
+          '<div class="action-label ' + action.kind + '">' + escapeHtml(action.kind) + '</div>' +
+          '<div class="task-title">' + escapeHtml(action.title) + '</div>' +
+          '<div class="task-meta">' + escapeHtml(action.body) + '</div>' +
+        '</div>'
+      )).join(""));
+    }
+
+    function renderQueues(tasks) {
+      const ready = (state.dispatchable.tasks || []).slice(0, 6);
+      const attention = tasks.filter(task => ATTENTION_STATES.has(task.current_state)).slice(0, 6);
+      const progress = tasks.filter(task => ACTIVE_STATES.has(task.current_state)).slice(0, 6);
+
+      document.getElementById("ready-count").textContent = ready.length + " task(s)";
+      document.getElementById("attention-count").textContent = attention.length + " task(s)";
+      document.getElementById("progress-count").textContent = progress.length + " task(s)";
+      document.getElementById("locks-count").textContent = Object.keys(state.locks || {}).length + " lock(s)";
+
+      setElementHtml("queue-ready", renderTaskCards(ready, "No dispatchable tasks"));
+      setElementHtml("queue-attention", renderTaskCards(attention, "No blocked, failed, or awaiting sync tasks"));
+      setElementHtml("queue-progress", renderTaskCards(progress, "No tasks are currently in motion"));
+    }
+
+    function renderLocks(locks) {
+      const entries = Object.entries(locks || {});
+      if (entries.length === 0) {
+        setListEmpty("locks", "No active locks");
+        return;
+      }
+      setElementHtml("locks", entries.map(([file, lock]) => (
+        '<div class="task-item">' +
+          '<div class="task-title mono">' + escapeHtml(file) + '</div>' +
+          '<div class="task-meta">' +
+            escapeHtml(lock.task_id + " | " + lock.agent + "@" + lock.node + " | expires " + lock.expires_at) +
+          '</div>' +
+        '</div>'
+      )).join(""));
+    }
+
+    function renderValidationDetail(validation) {
+      const entries = [];
+      (validation.orphaned_locks || []).forEach(item => entries.push("orphaned lock: " + item));
+      (validation.invalid_transitions || []).forEach(item => entries.push("invalid transition: " + item));
+      (validation.circular_dependencies || []).forEach(item => entries.push("cycle: " + item));
+      (validation.warnings || []).forEach(item => entries.push("warning: " + item));
+
+      if (entries.length === 0) {
+        setListEmpty("validation-detail", "No validation issues");
+        return;
+      }
+
+      setElementHtml("validation-detail", entries.map(item => (
+        '<div class="detail-item"><div class="list-meta">' + escapeHtml(item) + '</div></div>'
+      )).join(""));
+    }
+
+    function renderLedgerList() {
+      const payload = state.filteredTasksPayload || { tasks: [] };
+      const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+      document.getElementById("ledger-count").textContent = (payload.task_count || tasks.length) + " task(s)";
+      setElementHtml("ledger-results", renderTaskCards(tasks, "No tasks match the active filter"));
+    }
+
+    function syncSelectedTaskToFilteredLedger() {
+      const filteredTasks = Array.isArray(state.filteredTasksPayload.tasks)
+        ? state.filteredTasksPayload.tasks
+        : [];
+
+      if (filteredTasks.length === 0) {
+        state.selectedTaskId = null;
+        return;
+      }
+
+      const stillVisible = filteredTasks.some(task => task.id === state.selectedTaskId);
+      if (!stillVisible) {
+        state.selectedTaskId = filteredTasks[0].id;
+      }
+    }
+
+    function detailBlock(label, value) {
+      return (
+        '<div class="detail-block">' +
+          '<div class="detail-label">' + escapeHtml(label) + '</div>' +
+          '<div class="detail-value">' + value + '</div>' +
+        '</div>'
+      );
+    }
+
+    async function renderTaskDetail() {
+      const grid = document.getElementById("detail-grid");
+      if (!state.selectedTaskId) {
+        grid.innerHTML = "";
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/task/" + encodeURIComponent(state.selectedTaskId));
+        if (!response.ok) {
+          throw new Error("Task detail request failed");
+        }
+        const task = await response.json();
+        document.getElementById("detail-title").textContent = task.title || task.id;
+        document.getElementById("detail-summary").textContent =
+          (task.current_state || "unknown") + " · completion mode " + (task.completion_mode || "n/a");
+
+        const deps = Array.isArray(task.dependencies) && task.dependencies.length > 0
+          ? task.dependencies.map(escapeHtml).join("<br>")
+          : "none";
+        const branch = task.branch_name ? escapeHtml(task.branch_name) : "none";
+        const risk = task.impact ? escapeHtml(task.impact.risk_level || "n/a") : "n/a";
+        const review = task.github_evidence
+          ? escapeHtml(JSON.stringify(task.github_evidence, null, 2))
+          : "none";
+        const lock = task.lock
+          ? escapeHtml(JSON.stringify(task.lock, null, 2))
+          : "none";
+        const attachments = Array.isArray(task.context_attachments) && task.context_attachments.length > 0
+          ? task.context_attachments.slice(0, 6).map(item => (
+              escapeHtml(item.attachment_type + " | " + item.source + " | " + item.token_estimate + " tokens")
+            )).join("<br>")
+          : "none";
+
+        grid.innerHTML = [
+          detailBlock("Identity", '<div class="mono">' + escapeHtml(task.id) + '</div>'),
+          detailBlock("State", '<span class="' + badgeClass(task.current_state || "unknown") + '">' + escapeHtml(task.current_state || "unknown") + '</span>'),
+          detailBlock("Risk", '<span class="' + badgeClass((risk || "").toLowerCase()) + '">' + risk + '</span>'),
+          detailBlock("Dependencies", '<div class="mono">' + deps + '</div>'),
+          detailBlock("Branch", '<div class="mono">' + branch + '</div>'),
+          detailBlock("Lock", '<pre class="mono subtle">' + lock + '</pre>'),
+          detailBlock("GitHub Evidence", '<pre class="mono subtle">' + review + '</pre>'),
+          detailBlock("Context Attachments", '<div class="mono subtle">' + attachments + '</div>')
+        ].join("");
+      } catch (error) {
+        document.getElementById("detail-title").textContent = state.selectedTaskId;
+        document.getElementById("detail-summary").textContent = "Failed to load task detail.";
+        grid.innerHTML = detailBlock("Error", escapeHtml(error.message));
+      }
+    }
+
+    function buildTaskMap(tasks) {
+      const map = new Map();
+      tasks.forEach(task => map.set(task.id, task));
+      return map;
+    }
+
+    function renderDag(dag, tasks) {
+      const levels = Array.isArray(dag.levels) ? dag.levels : [];
+      const taskMap = buildTaskMap(tasks || []);
+      document.getElementById("frontier-count").textContent = String((state.dispatchable.task_ids || []).length);
+      document.getElementById("blocked-count").textContent = String(stateCount(tasks || [], task => task.current_state === "blocked"));
+      document.getElementById("level-count").textContent = String(levels.length);
+      document.getElementById("dependency-frontier").innerHTML = (state.dispatchable.task_ids || []).length > 0
+        ? state.dispatchable.task_ids.map(taskId => '<span class="pill mono">' + escapeHtml(taskId) + '</span>').join("")
+        : '<span class="pill">No dispatchable frontier yet</span>';
+
+      const blocked = (tasks || []).filter(task => task.current_state === "blocked").map(task => task.id);
+      const summary = [];
+      summary.push(levels.length > 0 ? levels.length + " dependency level(s) are present." : "No DAG levels are available.");
+      summary.push((state.dispatchable.task_ids || []).length > 0
+        ? "Dispatchable frontier: " + state.dispatchable.task_ids.join(", ") + "."
+        : "Nothing is dispatchable right now.");
+      summary.push(blocked.length > 0
+        ? "Blocked chain includes " + blocked.slice(0, 5).join(", ") + "."
+        : "No blocked chain is currently visible.");
+      document.getElementById("dependency-summary-text").textContent = summary.join(" ");
+
+      if (levels.length === 0) {
+        setElementHtml("dag-board", '<div class="panel"><div class="empty">No DAG levels available</div></div>');
+        return;
+      }
+
+      setElementHtml("dag-board", levels.map((level, index) => {
+        const nodes = level.map(taskId => {
+          const task = taskMap.get(taskId) || { id: taskId, title: taskId, current_state: "unknown", dependencies: [] };
+          const dependents = (tasks || []).filter(candidate => (candidate.dependencies || []).includes(taskId)).length;
+          const selected = taskId === state.selectedTaskId ? " selected" : "";
+          const frontier = (state.dispatchable.task_ids || []).includes(taskId)
+            ? '<span class="tiny-pill dispatchable">dispatchable</span>'
+            : "";
+          return (
+            '<div class="node-card clickable' + selected + '" data-task-id="' + escapeHtml(taskId) + '">' +
+              '<div class="node-top">' +
+                '<div>' +
+                  '<div class="node-title">' + escapeHtml(task.title || taskId) + '</div>' +
+                  '<div class="task-id subtle">' + escapeHtml(taskId) + '</div>' +
+                '</div>' +
+                '<span class="' + badgeClass(task.current_state || "unknown") + '">' + escapeHtml(task.current_state || "unknown") + '</span>' +
+              '</div>' +
+              '<div class="task-meta">' + escapeHtml("deps " + ((task.dependencies || []).length) + " | dependents " + dependents + " | risk " + (task.impact_risk || "n/a")) + '</div>' +
+              '<div class="node-pressure">' +
+                frontier +
+                '<span class="tiny-pill">fan-in ' + escapeHtml(String((task.dependencies || []).length)) + '</span>' +
+                '<span class="tiny-pill">fan-out ' + escapeHtml(String(dependents)) + '</span>' +
+              '</div>' +
+            '</div>'
+          );
+        }).join("");
+
+        return (
+          '<section class="level-card">' +
+            '<div class="level-head">' +
+              '<div class="level-title">Level ' + index + '</div>' +
+              '<div class="level-count">' + level.length + ' node(s)</div>' +
+            '</div>' +
+            '<div class="node-grid">' + nodes + '</div>' +
+          '</section>'
+        );
+      }).join(""));
+    }
+
+    function bindTaskClicks() {
+      document.querySelectorAll("[data-task-id]").forEach(element => {
+        element.addEventListener("click", () => {
+          const taskId = element.getAttribute("data-task-id");
+          const inDependencyView = element.closest("#view-dependency");
+          selectTask(taskId, inDependencyView ? "ledger" : "ledger");
+        });
+      });
+    }
+
+    function syncFiltersFromUrl() {
+      const params = queryParams();
+      document.getElementById("filter-state").value = params.get("state") || "";
+      document.getElementById("filter-risk").value = params.get("risk") || "";
+      document.getElementById("filter-since").value = params.get("since") || "";
+    }
+
+    function bindTabs() {
+      document.querySelectorAll(".tab").forEach(button => {
+        button.addEventListener("click", () => switchView(button.dataset.view));
+      });
+    }
+
+    function bindFilterControls() {
+      document.getElementById("ledger-filters").addEventListener("submit", event => {
+        event.preventDefault();
+        applyUiStateToUrl({
+          state: document.getElementById("filter-state").value,
+          risk: document.getElementById("filter-risk").value,
+          since: document.getElementById("filter-since").value,
+          view: "ledger"
+        });
+        refresh();
+      });
+
+      document.getElementById("filters-reset").addEventListener("click", () => {
+        document.getElementById("filter-state").value = "";
+        document.getElementById("filter-risk").value = "";
+        document.getElementById("filter-since").value = "";
+        applyUiStateToUrl({ state: null, risk: null, since: null, view: "ledger" });
+        refresh();
+      });
+    }
+
+    async function refresh() {
+      syncFiltersFromUrl();
+      switchView(currentView());
+      try {
+        const filterQuery = currentFilterQuery();
+        const [allTasksRes, filteredTasksRes, statsRes, validateRes, locksRes, dagRes, dispatchableRes] = await Promise.all([
+          fetch("/api/tasks"),
+          fetch("/api/tasks" + filterQuery),
+          fetch("/api/stats"),
+          fetch("/api/validate"),
+          fetch("/api/locks"),
+          fetch("/api/dag"),
+          fetch("/api/dispatchable")
+        ]);
+
+        const responses = [allTasksRes, filteredTasksRes, statsRes, validateRes, locksRes, dagRes, dispatchableRes];
+        if (responses.some(response => !response.ok)) {
+          throw new Error("API request failed");
+        }
+
+        const [allTasksPayload, filteredTasksPayload, stats, validation, locks, dag, dispatchable] = await Promise.all(
+          responses.map(response => response.json())
+        );
+
+        state.allTasksPayload = allTasksPayload;
+        state.filteredTasksPayload = filteredTasksPayload;
+        state.stats = stats;
+        state.validation = validation;
+        state.locks = locks;
+        state.dag = dag;
+        state.dispatchable = dispatchable;
+
+        const allTasks = Array.isArray(allTasksPayload.tasks) ? allTasksPayload.tasks : [];
+        renderHealth(allTasks, stats, validation, locks, dispatchable);
+        renderNextActions(allTasks, validation, dispatchable);
+        renderQueues(allTasks);
+        renderLocks(locks);
+        renderValidationDetail(validation);
+        renderLedgerList();
+        renderDag(dag, allTasks);
+        document.getElementById("meta").textContent =
+          "Snapshot version " + allTasksPayload.version +
+          " · updated " + allTasksPayload.generated_at +
+          " · auto-refresh every 3s";
+
+        if (!state.selectedTaskId) {
+          const preferred = (dispatchable.task_ids || [])[0] || (filteredTasksPayload.tasks || [])[0]?.id || allTasks[0]?.id || null;
+          state.selectedTaskId = preferred;
+        }
+        syncSelectedTaskToFilteredLedger();
+        await renderTaskDetail();
+        bindTaskClicks();
+      } catch (error) {
+        document.getElementById("hero-status").className = "hero-status error";
+        document.getElementById("hero-status").textContent = "Dashboard Unavailable";
+        document.getElementById("health-summary").textContent = "Dashboard data could not be loaded.";
+        document.getElementById("meta").textContent = "Refresh failed: " + error.message;
+        ["next-actions", "queue-ready", "queue-attention", "queue-progress", "locks", "validation-detail", "ledger-results", "dag-board"].forEach(id => {
+          setListEmpty(id, "Failed to load data");
+        });
+      }
+    }
+
+    bindTabs();
+    bindFilterControls();
+    refresh();
+    setInterval(refresh, 3000);
+  </script>
+</body>
+</html>

--- a/crates/mergegate-cli/src/main.rs
+++ b/crates/mergegate-cli/src/main.rs
@@ -1581,8 +1581,11 @@ fn parse_export_filter(
     let since = args.since.as_deref().map(parse_export_since).transpose()?;
 
     Ok(Some(miyabi_core::export::ExportFilter {
-        state: args.state,
-        risk_level: args.risk,
+        // TaskState serialises as snake_case; normalise to lowercase so users can pass
+        // either "Implementing" or "implementing" interchangeably.
+        state: args.state.map(|s| s.to_ascii_lowercase()),
+        // ImpactRiskLevel serialises as SCREAMING_SNAKE_CASE; normalise to uppercase.
+        risk_level: args.risk.map(|r| r.to_ascii_uppercase()),
         since,
     }))
 }
@@ -3306,6 +3309,21 @@ mod tests {
 
         assert!(filter.is_none());
     }
+
+    #[test]
+    fn parse_export_filter_normalises_state_and_risk_case() {
+        let filter = parse_export_filter(ExportFilterArgs {
+            state: Some("Implementing".to_string()),
+            risk: Some("high".to_string()),
+            since: None,
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(filter.state.as_deref(), Some("implementing"));
+        assert_eq!(filter.risk_level.as_deref(), Some("HIGH"));
+    }
+
 
     #[test]
     fn validate_returns_warning_exit_code_for_missing_dependency_reference() {

--- a/crates/mergegate-cli/src/main.rs
+++ b/crates/mergegate-cli/src/main.rs
@@ -1,7 +1,6 @@
 /// MergeGate CLI - Main entry point
-
-use chrono::Duration as ChronoDuration;
-use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use miyabi_core::{FeatureFlagManager, RulesLoader};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -147,6 +146,19 @@ enum ImpactRiskArg {
     Critical,
 }
 
+#[derive(Clone, Debug, Args)]
+struct ExportFilterArgs {
+    /// Filter by task state (e.g. implementing, done)
+    #[arg(long)]
+    state: Option<String>,
+    /// Filter by impact risk (LOW, MEDIUM, HIGH, CRITICAL)
+    #[arg(long)]
+    risk: Option<String>,
+    /// Filter by created-at timestamp (RFC3339)
+    #[arg(long)]
+    since: Option<String>,
+}
+
 #[derive(Subcommand)]
 enum GateCommand {
     /// Initialize project memory for the current repository
@@ -245,6 +257,20 @@ enum GateCommand {
     Locks,
     /// Show DAG levels
     Dag,
+    /// Validate snapshot consistency
+    Validate,
+    /// Export tasks as JSON
+    ExportJson {
+        #[command(flatten)]
+        filter: ExportFilterArgs,
+    },
+    /// Export tasks as Markdown
+    ExportMd {
+        #[command(flatten)]
+        filter: ExportFilterArgs,
+    },
+    /// Show task statistics
+    Stats,
     /// Show dispatchable tasks
     Dispatchable,
     /// Serve a minimal web dashboard
@@ -1069,6 +1095,7 @@ fn handle_gate_command(
     use miyabi_core::store::{CompletionMode, ImpactRiskLevel};
 
     let protocol = DeterministicExecutionProtocol::from_store_path(store_path.to_path_buf());
+    let mut success_code = 0;
     let actor = "miyabi-cli";
     let node = std::env::var("HOSTNAME")
         .ok()
@@ -1365,6 +1392,50 @@ fn handle_gate_command(
                 }
             }
         }),
+        GateCommand::Validate => load_snapshot(store_path)
+            .map_err(ProtocolError::Internal)
+            .map(|snapshot| {
+                let report = miyabi_core::validate::validate_snapshot(&snapshot);
+                success_code = report.exit_code();
+                if emit_event {
+                    emit_gate_event("validation_reported", None, &report);
+                } else if matches!(format, OutputFormat::Json) {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&validation_report_json(&report)).unwrap()
+                    );
+                } else {
+                    println!("{report}");
+                }
+            }),
+        GateCommand::ExportJson { filter } => load_snapshot(store_path)
+            .map_err(ProtocolError::Internal)
+            .and_then(|snapshot| {
+                let filter = parse_export_filter(filter)
+                    .map_err(|error| ProtocolError::input(error.to_string()))?;
+                let export = miyabi_core::export::export_json(&snapshot, filter);
+                println!("{export}");
+                Ok(())
+            }),
+        GateCommand::ExportMd { filter } => load_snapshot(store_path)
+            .map_err(ProtocolError::Internal)
+            .and_then(|snapshot| {
+                let filter = parse_export_filter(filter)
+                    .map_err(|error| ProtocolError::input(error.to_string()))?;
+                let export = miyabi_core::export_md::export_markdown(&snapshot, filter.as_ref());
+                println!("{export}");
+                Ok(())
+            }),
+        GateCommand::Stats => load_snapshot(store_path)
+            .map_err(ProtocolError::Internal)
+            .map(|snapshot| {
+                let stats = miyabi_core::stats::compute_stats(&snapshot);
+                if matches!(format, OutputFormat::Json) {
+                    println!("{}", serde_json::to_string_pretty(&stats).unwrap());
+                } else {
+                    println!("{stats}");
+                }
+            }),
         GateCommand::Dispatchable => protocol.dispatchable().map(|report| {
             if emit_event {
                 emit_gate_event("dispatchable_reported", None, &report);
@@ -1467,7 +1538,7 @@ fn handle_gate_command(
     };
 
     Ok(match result {
-        Ok(()) => 0,
+        Ok(()) => success_code,
         Err(ProtocolError::GateRejected(message)) => {
             emit_gate_error(format, emit_event, "gate_rejected", &message);
             1
@@ -1484,6 +1555,56 @@ fn handle_gate_command(
             emit_gate_error(format, emit_event, "internal_error", &error.to_string());
             1
         }
+    })
+}
+
+fn load_snapshot(
+    store_path: &std::path::Path,
+) -> Result<miyabi_core::store::TasksSnapshot, miyabi_core::Error> {
+    let snapshot_store = miyabi_core::store::SnapshotStore::new(
+        store_path.to_path_buf(),
+        store_path
+            .parent()
+            .map(|parent| parent.join(".tasks.lock"))
+            .unwrap_or_else(|| PathBuf::from(".tasks.lock")),
+    );
+    snapshot_store.load()
+}
+
+fn parse_export_filter(
+    args: ExportFilterArgs,
+) -> anyhow::Result<Option<miyabi_core::export::ExportFilter>> {
+    if args.state.is_none() && args.risk.is_none() && args.since.is_none() {
+        return Ok(None);
+    }
+
+    let since = args.since.as_deref().map(parse_export_since).transpose()?;
+
+    Ok(Some(miyabi_core::export::ExportFilter {
+        state: args.state,
+        risk_level: args.risk,
+        since,
+    }))
+}
+
+fn parse_export_since(value: &str) -> anyhow::Result<DateTime<Utc>> {
+    let parsed = DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .or_else(|_| {
+            chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .map(|date| date.and_hms_opt(0, 0, 0).expect("valid midnight").and_utc())
+        })?;
+    Ok(parsed)
+}
+
+fn validation_report_json(report: &miyabi_core::validate::ValidationReport) -> serde_json::Value {
+    serde_json::json!({
+        "severity": report.severity(),
+        "exit_code": report.exit_code(),
+        "orphaned_locks": report.orphaned_locks,
+        "invalid_transitions": report.invalid_transitions,
+        "circular_dependencies": report.circular_dependencies,
+        "warnings": report.warnings,
     })
 }
 
@@ -1622,7 +1743,11 @@ fn print_gate_task_status(task: &miyabi_core::store::ExecutionTask) {
         miyabi_core::store::TaskState::Pending | miyabi_core::store::TaskState::Draft => {
             if task.impact.is_none() {
                 println!("next:");
-                println!("  {} {} --risk low --symbols 0", gate_command("impact"), task.id);
+                println!(
+                    "  {} {} --risk low --symbols 0",
+                    gate_command("impact"),
+                    task.id
+                );
                 println!(
                     "  {} {} --agent <name> --node <machine> --files \"path/to/file\"",
                     gate_command("assign"),
@@ -1665,7 +1790,10 @@ fn print_gate_snapshot_status(
         println!("this is not an error. it means the ledger is empty.");
         println!("next:");
         println!("  {}", gate_command("init"));
-        println!("  {} --issue <N> --title \"Your task\"", gate_command("register"));
+        println!(
+            "  {} --issue <N> --title \"Your task\"",
+            gate_command("register")
+        );
         println!("  {}", gate_command("guide"));
         return;
     }
@@ -2222,9 +2350,30 @@ cargo clippy --all-targets --all-features -- -D warnings
   Show DAG dependency levels.
   {{GATE}} dag
 
+### validate
+  Validate snapshot consistency.
+  {{GATE}} validate
+  {{GATE}} --format json validate
+
 ### dispatchable
   Show tasks ready to be worked on (dependencies resolved, no lock).
   {{GATE}} dispatchable
+
+### export-json
+  Export tasks as filtered JSON.
+  {{GATE}} export-json
+  {{GATE}} export-json --state implementing --risk HIGH
+  {{GATE}} export-json --since 2026-04-12T00:00:00Z
+
+### export-md
+  Export tasks as filtered Markdown.
+  {{GATE}} export-md
+  {{GATE}} export-md --state pending --since 2026-04-12
+
+### stats
+  Show aggregate task statistics.
+  {{GATE}} stats
+  {{GATE}} --format json stats
 
 ### attach
   View context attachments for a task.
@@ -2286,79 +2435,196 @@ const POLARIS_DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
   <style>
     :root {
       color-scheme: light;
-      --bg: #f4f7fb;
-      --panel: #ffffff;
-      --text: #162033;
+      --bg: #f5f7fb;
+      --panel: rgba(255,255,255,0.92);
+      --panel-strong: #ffffff;
+      --text: #172033;
       --muted: #667085;
-      --border: #d6dfeb;
+      --border: #d9e1ec;
+      --shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+      --success: #15803d;
+      --warning: #b45309;
+      --danger: #b42318;
+      --info: #2563eb;
+      --neutral: #475467;
+      --hero-a: #eff6ff;
+      --hero-b: #fdf2f8;
+      --hero-c: #f8fafc;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color: var(--text);
-      background: linear-gradient(180deg, #eef4ff 0%, #f8fafc 55%, #f4f7fb 100%);
+      background:
+        radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 32%),
+        radial-gradient(circle at top right, rgba(190, 24, 93, 0.08), transparent 28%),
+        linear-gradient(180deg, var(--hero-a) 0%, var(--hero-b) 35%, var(--hero-c) 100%);
     }
     .shell {
-      max-width: 1120px;
+      max-width: 1240px;
       margin: 0 auto;
-      padding: 16px;
+      padding: 18px;
     }
-    header, .panel {
-      background: rgba(255, 255, 255, 0.9);
+    .panel, .hero {
+      background: var(--panel);
       border: 1px solid var(--border);
-      border-radius: 18px;
-      box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+      border-radius: 24px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(8px);
     }
-    header {
-      padding: 20px;
-      margin-bottom: 16px;
+    .hero {
+      padding: 22px;
+      margin-bottom: 18px;
+      display: grid;
+      gap: 18px;
+    }
+    .hero-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
     }
     h1 {
       margin: 0 0 8px;
-      font-size: clamp(1.6rem, 3vw, 2.4rem);
+      font-size: clamp(1.9rem, 4vw, 3rem);
+      line-height: 1.05;
     }
     h2 {
-      margin: 0 0 12px;
-      font-size: 1.05rem;
+      margin: 0 0 14px;
+      font-size: 1rem;
+      letter-spacing: 0.01em;
     }
-    .subtitle, .meta {
-      margin: 0;
+    h3 {
+      margin: 0 0 8px;
+      font-size: 0.98rem;
+    }
+    p { margin: 0; }
+    .subtitle, .meta, .muted, .list-meta {
       color: var(--muted);
     }
-    .grid {
-      display: grid;
-      gap: 16px;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    .hero-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 16px;
+      border-radius: 999px;
+      font-weight: 700;
+      font-size: 0.95rem;
+      border: 1px solid transparent;
+      white-space: nowrap;
     }
-    .panel {
+    .hero-status.clean {
+      color: var(--success);
+      background: rgba(21, 128, 61, 0.12);
+      border-color: rgba(21, 128, 61, 0.2);
+    }
+    .hero-status.warning {
+      color: var(--warning);
+      background: rgba(180, 83, 9, 0.12);
+      border-color: rgba(180, 83, 9, 0.2);
+    }
+    .hero-status.error {
+      color: var(--danger);
+      background: rgba(180, 35, 24, 0.12);
+      border-color: rgba(180, 35, 24, 0.2);
+    }
+    .hero-summary {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+    .metric {
+      background: var(--panel-strong);
+      border: 1px solid var(--border);
+      border-radius: 18px;
       padding: 16px;
     }
-    .task-list, .dag-list, .lock-list {
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-bottom: 8px;
+    }
+    .metric-value {
+      font-size: clamp(1.5rem, 3vw, 2.2rem);
+      font-weight: 800;
+      line-height: 1;
+    }
+    .metric-note {
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+    .layout {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: 1.15fr 0.85fr;
+    }
+    .stack {
+      display: grid;
+      gap: 18px;
+    }
+    .panel {
+      padding: 18px;
+    }
+    .section-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+    .section-kicker {
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+    .action-list, .task-list, .detail-list {
       list-style: none;
       margin: 0;
       padding: 0;
       display: grid;
-      gap: 10px;
+      gap: 12px;
     }
-    .task-item, .dag-item, .lock-item {
-      padding: 12px;
+    .action-item, .task-item, .detail-item {
       border: 1px solid var(--border);
-      border-radius: 14px;
-      background: #fbfdff;
+      border-radius: 18px;
+      background: var(--panel-strong);
+      padding: 14px;
     }
+    .action-item {
+      display: grid;
+      gap: 6px;
+    }
+    .action-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.82rem;
+      font-weight: 800;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+    .action-label.error { color: var(--danger); }
+    .action-label.warning { color: var(--warning); }
+    .action-label.info { color: var(--info); }
     .task-top {
       display: flex;
       justify-content: space-between;
-      align-items: center;
-      gap: 8px;
-      margin-bottom: 6px;
+      align-items: flex-start;
+      gap: 10px;
+      margin-bottom: 8px;
     }
     .task-title {
-      font-weight: 600;
+      font-weight: 700;
+      line-height: 1.35;
       word-break: break-word;
     }
-    .task-meta, .dag-meta, .lock-meta {
+    .task-id {
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-top: 3px;
+    }
+    .task-meta {
       font-size: 0.9rem;
       color: var(--muted);
     }
@@ -2366,216 +2632,469 @@ const POLARIS_DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
       display: inline-flex;
       justify-content: center;
       align-items: center;
-      min-width: 92px;
-      padding: 4px 10px;
+      min-width: 96px;
+      padding: 5px 11px;
       border-radius: 999px;
-      color: #ffffff;
-      font-size: 0.82rem;
-      font-weight: 700;
+      color: white;
+      font-size: 0.8rem;
+      font-weight: 800;
       text-transform: lowercase;
+      letter-spacing: 0.01em;
+    }
+    .badge.pending { background: var(--neutral); }
+    .badge.implementing { background: var(--info); }
+    .badge.reviewing { background: #7c3aed; }
+    .badge.done, .badge.merged { background: var(--success); }
+    .badge.blocked, .badge.failed, .badge.cancelled { background: var(--danger); }
+    .badge.draft, .badge.analyzing, .badge.deploying, .badge.awaiting_github_sync {
+      background: #64748b;
+    }
+    .summary-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border-radius: 999px;
+      padding: 7px 12px;
+      font-size: 0.84rem;
+      font-weight: 700;
+      background: #f3f6fb;
+      color: var(--text);
+      border: 1px solid var(--border);
     }
     .empty {
       color: var(--muted);
       font-style: italic;
+      padding: 2px 0;
+    }
+    details {
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--panel-strong);
+      padding: 14px 16px;
+    }
+    summary {
+      cursor: pointer;
+      list-style: none;
+      font-weight: 700;
+    }
+    summary::-webkit-details-marker { display: none; }
+    .details-grid {
+      margin-top: 14px;
+      display: grid;
+      gap: 12px;
+    }
+    .detail-item strong {
+      display: block;
+      margin-bottom: 6px;
+    }
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .hero-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
     }
     @media (max-width: 640px) {
       .shell { padding: 12px; }
-      header, .panel { border-radius: 14px; }
-      .task-top { align-items: flex-start; flex-direction: column; }
+      .hero, .panel { border-radius: 18px; }
+      .hero-top, .task-top {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .hero-summary {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
 <body>
   <div class="shell">
-    <header>
-      <h1>MergeGate Dashboard</h1>
-      <p class="subtitle">Deterministic Task Protocol live view</p>
+    <section class="hero">
+      <div class="hero-top">
+        <div>
+          <h1>MergeGate Control Tower</h1>
+          <p class="subtitle">まず結論、その次にやること、そのあと詳細を見るための画面です。</p>
+        </div>
+        <div id="hero-status" class="hero-status clean">Loading status...</div>
+      </div>
       <p class="meta" id="meta">Loading...</p>
-    </header>
-    <section class="grid">
-      <article class="panel" id="stats-panel">
-        <h2>Completion Stats</h2>
-        <div id="stats" class="empty">Loading stats...</div>
-      </article>
-      <article class="panel">
-        <h2>Tasks</h2>
-        <ul id="tasks" class="task-list"><li class="empty">Loading tasks...</li></ul>
-      </article>
-      <article class="panel">
-        <h2>DAG Levels</h2>
-        <ul id="dag" class="dag-list"><li class="empty">Loading DAG...</li></ul>
-      </article>
-      <article class="panel">
-        <h2>File Locks</h2>
-        <ul id="locks" class="lock-list"><li class="empty">Loading locks...</li></ul>
-      </article>
+      <div class="hero-summary">
+        <div class="metric">
+          <div class="metric-label">Dispatchable Tasks</div>
+          <div class="metric-value" id="metric-dispatchable">-</div>
+          <div class="metric-note">いま着手できるタスク数</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Validation Issues</div>
+          <div class="metric-value" id="metric-issues">-</div>
+          <div class="metric-note">lock / transition / cycle / warning</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Active Locks</div>
+          <div class="metric-value" id="metric-locks">-</div>
+          <div class="metric-note">いま競合しうるファイルロック数</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Completion</div>
+          <div class="metric-value" id="metric-completion">-</div>
+          <div class="metric-note">全体の完了率</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="layout">
+      <div class="stack">
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <h2>Next Actions</h2>
+              <p class="section-kicker">ここだけ見れば、次に何をすべきかが分かります。</p>
+            </div>
+          </div>
+          <ul id="next-actions" class="action-list"><li class="empty">Loading actions...</li></ul>
+        </article>
+
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <h2>Work Queues</h2>
+              <p class="section-kicker">着手可能、進行中、詰まり、完了を分けて表示します。</p>
+            </div>
+          </div>
+          <div class="stack">
+            <div>
+              <h3>Ready To Start</h3>
+              <ul id="queue-ready" class="task-list"><li class="empty">Loading...</li></ul>
+            </div>
+            <div>
+              <h3>Needs Attention</h3>
+              <ul id="queue-attention" class="task-list"><li class="empty">Loading...</li></ul>
+            </div>
+            <div>
+              <h3>In Progress</h3>
+              <ul id="queue-progress" class="task-list"><li class="empty">Loading...</li></ul>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div class="stack">
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <h2>Current Health</h2>
+              <p class="section-kicker">今のシステム状態を短くまとめます。</p>
+            </div>
+          </div>
+          <div id="health-summary" class="empty">Loading health...</div>
+          <div id="health-pills" class="summary-strip"></div>
+        </article>
+
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <h2>Active Locks</h2>
+              <p class="section-kicker">競合の原因になりやすい箇所です。</p>
+            </div>
+          </div>
+          <ul id="locks" class="task-list"><li class="empty">Loading locks...</li></ul>
+        </article>
+
+        <details open>
+          <summary>Deeper Detail</summary>
+          <div class="details-grid">
+            <div class="detail-item">
+              <strong>Validation Detail</strong>
+              <ul id="validation-detail" class="detail-list"><li class="empty">Loading...</li></ul>
+            </div>
+            <div class="detail-item">
+              <strong>DAG Levels</strong>
+              <ul id="dag" class="detail-list"><li class="empty">Loading...</li></ul>
+            </div>
+          </div>
+        </details>
+      </div>
     </section>
   </div>
   <script>
-    const stateColors = {
-      pending: "#6b7280",
-      implementing: "#2563eb",
-      merged: "#15803d",
-      done: "#15803d",
-      blocked: "#dc2626"
-    };
+    const ACTIVE_STATES = new Set(["analyzing", "implementing", "reviewing", "deploying"]);
+    const WAITING_STATES = new Set(["draft", "pending", "blocked", "awaiting_github_sync"]);
+    const DONE_STATES = new Set(["done", "merged"]);
 
-    function setEmpty(id, message) {
-      document.getElementById(id).innerHTML = '<li class="empty">' + message + '</li>';
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
     }
 
-    function colorForState(state) {
-      return stateColors[state] || "#7c3aed";
+    function setListEmpty(id, message) {
+      document.getElementById(id).innerHTML = '<li class="empty">' + escapeHtml(message) + '</li>';
     }
 
-    function renderTasks(snapshot) {
-      const tasks = Array.isArray(snapshot.tasks) ? snapshot.tasks : [];
-      const el = document.getElementById("tasks");
-      if (tasks.length === 0) {
-        setEmpty("tasks", "No tasks in snapshot");
+    function badgeClass(state) {
+      return "badge " + (state || "unknown");
+    }
+
+    function taskMeta(task) {
+      const deps = Array.isArray(task.dependencies) && task.dependencies.length > 0
+        ? task.dependencies.join(", ")
+        : "none";
+      return "priority " + task.priority + " | deps: " + deps;
+    }
+
+    function renderTaskList(id, tasks, emptyMessage) {
+      const el = document.getElementById(id);
+      if (!Array.isArray(tasks) || tasks.length === 0) {
+        setListEmpty(id, emptyMessage);
         return;
       }
 
-      el.innerHTML = "";
-      for (const task of tasks) {
-        const item = document.createElement("li");
-        item.className = "task-item";
+      el.innerHTML = tasks.map(task => {
+        const state = task.current_state || "unknown";
+        return (
+          '<li class="task-item">' +
+            '<div class="task-top">' +
+              '<div>' +
+                '<div class="task-title">' + escapeHtml(task.title) + '</div>' +
+                '<div class="task-id">' + escapeHtml(task.id) + '</div>' +
+              '</div>' +
+              '<span class="' + badgeClass(state) + '">' + escapeHtml(state) + '</span>' +
+            '</div>' +
+            '<div class="task-meta">' + escapeHtml(taskMeta(task)) + '</div>' +
+          '</li>'
+        );
+      }).join("");
+    }
 
-        const top = document.createElement("div");
-        top.className = "task-top";
-
-        const title = document.createElement("div");
-        title.className = "task-title";
-        title.textContent = task.title + " (" + task.id + ")";
-
-        const badge = document.createElement("span");
-        badge.className = "badge";
-        badge.style.background = colorForState(task.current_state);
-        badge.textContent = task.current_state;
-
-        top.appendChild(title);
-        top.appendChild(badge);
-
-        const meta = document.createElement("div");
-        meta.className = "task-meta";
-        const deps = Array.isArray(task.dependencies) && task.dependencies.length > 0
-          ? task.dependencies.join(", ")
-          : "none";
-        meta.textContent = "priority " + task.priority + " | deps: " + deps;
-
-        item.appendChild(top);
-        item.appendChild(meta);
-        el.appendChild(item);
+    function renderLockList(locks) {
+      const entries = Object.entries(locks || {});
+      if (entries.length === 0) {
+        setListEmpty("locks", "No active locks");
+        return;
       }
+
+      document.getElementById("locks").innerHTML = entries.map(([file, lock]) => (
+        '<li class="task-item">' +
+          '<div class="task-title">' + escapeHtml(file) + '</div>' +
+          '<div class="task-meta">' +
+            escapeHtml(lock.agent + "@" + lock.node + " | task: " + lock.task_id) +
+          '</div>' +
+        '</li>'
+      )).join("");
+    }
+
+    function renderDetailList(id, values, emptyMessage) {
+      if (!Array.isArray(values) || values.length === 0) {
+        setListEmpty(id, emptyMessage);
+        return;
+      }
+
+      document.getElementById(id).innerHTML = values
+        .map(value => '<li class="detail-item"><div class="list-meta">' + escapeHtml(value) + '</div></li>')
+        .join("");
     }
 
     function renderDag(report) {
       const levels = Array.isArray(report.levels) ? report.levels : [];
-      const el = document.getElementById("dag");
       if (levels.length === 0) {
-        setEmpty("dag", "No DAG levels available");
+        setListEmpty("dag", "No DAG levels available");
         return;
       }
 
-      el.innerHTML = "";
-      levels.forEach((level, index) => {
-        const item = document.createElement("li");
-        item.className = "dag-item";
-
-        const title = document.createElement("div");
-        title.className = "task-title";
-        title.textContent = "Level " + index;
-
-        const meta = document.createElement("div");
-        meta.className = "dag-meta";
-        meta.textContent = Array.isArray(level) && level.length > 0 ? level.join(", ") : "empty";
-
-        item.appendChild(title);
-        item.appendChild(meta);
-        el.appendChild(item);
-      });
+      document.getElementById("dag").innerHTML = levels.map((level, index) => (
+        '<li class="detail-item">' +
+          '<strong>Level ' + index + '</strong>' +
+          '<div class="list-meta">' + escapeHtml(level.length > 0 ? level.join(", ") : "empty") + '</div>' +
+        '</li>'
+      )).join("");
     }
 
-    function renderLocks(locks) {
-      const entries = Object.entries(locks || {});
-      const el = document.getElementById("locks");
-      if (entries.length === 0) {
-        setEmpty("locks", "No active file locks");
-        return;
-      }
-
-      el.innerHTML = "";
-      for (const [file, lock] of entries) {
-        const item = document.createElement("li");
-        item.className = "lock-item";
-
-        const title = document.createElement("div");
-        title.className = "task-title";
-        title.textContent = file;
-
-        const meta = document.createElement("div");
-        meta.className = "lock-meta";
-        meta.textContent = lock.agent + "@" + lock.node + " | task: " + lock.task_id;
-
-        item.appendChild(title);
-        item.appendChild(meta);
-        el.appendChild(item);
-      }
+    function validationIssueCount(report) {
+      return (
+        (report.orphaned_locks || []).length +
+        (report.invalid_transitions || []).length +
+        (report.circular_dependencies || []).length +
+        (report.warnings || []).length
+      );
     }
 
-    function renderStats(snapshot) {
-      const tasks = Array.isArray(snapshot.tasks) ? snapshot.tasks : [];
-      if (tasks.length === 0) {
-        document.getElementById("stats").innerHTML = '<span class="empty">No tasks</span>';
-        return;
+    function setHeroStatus(severity, issueCount, dispatchableCount) {
+      const el = document.getElementById("hero-status");
+      const statusText = severity === "error"
+        ? "Action Needed"
+        : severity === "warning"
+          ? "Review Needed"
+          : dispatchableCount > 0
+            ? "Ready To Move"
+            : "Healthy";
+      el.className = "hero-status " + severity;
+      el.textContent = statusText + " · " + issueCount + " issue(s)";
+    }
+
+    function renderMetrics(stats, locks, dispatchableCount, issueCount) {
+      document.getElementById("metric-dispatchable").textContent = String(dispatchableCount);
+      document.getElementById("metric-issues").textContent = String(issueCount);
+      document.getElementById("metric-locks").textContent = String(Object.keys(locks || {}).length);
+      document.getElementById("metric-completion").textContent =
+        (Math.round(stats.completion_rate_pct || 0)) + "%";
+    }
+
+    function renderHealth(stats, validation, tasks, locks) {
+      const parts = [];
+      if (validation.severity === "error") {
+        parts.push("整合性エラーがあるため、まず validation を解消する必要があります。");
+      } else if (validation.severity === "warning") {
+        parts.push("致命的ではない warning があります。作業前に確認すると安全です。");
+      } else {
+        parts.push("ledger の整合性は保たれています。");
       }
-      const done = tasks.filter(t => t.current_state === "done" || t.current_state === "merged").length;
-      const active = tasks.filter(t => t.current_state === "implementing" || t.current_state === "reviewing").length;
-      const pending = tasks.filter(t => t.current_state === "pending" || t.current_state === "draft" || t.current_state === "blocked").length;
-      const total = tasks.length;
-      const pct = total > 0 ? Math.round(done / total * 100) : 0;
 
-      const bar = '<div style="background:#e5e7eb;border-radius:8px;height:20px;margin:8px 0;overflow:hidden">' +
-        '<div style="background:#15803d;height:100%;width:' + pct + '%;transition:width .3s"></div></div>';
+      const active = tasks.filter(task => ACTIVE_STATES.has(task.current_state)).length;
+      const blocked = tasks.filter(task => task.current_state === "blocked").length;
+      parts.push(active > 0 ? active + " 件のタスクが進行中です。" : "進行中タスクはありません。");
+      parts.push(blocked > 0 ? blocked + " 件の blocked タスクがあります。" : "blocked タスクはありません。");
 
-      document.getElementById("stats").innerHTML =
-        '<div style="font-size:2rem;font-weight:700">' + pct + '%</div>' +
-        '<div class="task-meta">completed</div>' + bar +
-        '<div class="task-meta">' + done + ' done / ' + active + ' active / ' + pending + ' pending / ' + total + ' total</div>';
+      document.getElementById("health-summary").textContent = parts.join(" ");
+      document.getElementById("health-pills").innerHTML = [
+        ["completed", stats.completed + " completed"],
+        ["active", stats.active + " active"],
+        ["waiting", stats.waiting + " waiting"],
+        ["failed", stats.failed + " failed"],
+        ["locks", Object.keys(locks || {}).length + " locks"]
+      ].map(([_, label]) => '<span class="pill">' + escapeHtml(label) + '</span>').join("");
+    }
+
+    function renderNextActions(tasks, validation, locks) {
+      const actions = [];
+
+      if ((validation.invalid_transitions || []).length > 0 || (validation.orphaned_locks || []).length > 0) {
+        actions.push({
+          kind: "error",
+          title: "Fix ledger consistency first",
+          body: "Run `mergegate gate validate` and resolve lock or transition mismatches before assigning more work."
+        });
+      }
+
+      const blocked = tasks.filter(task => task.current_state === "blocked");
+      if (blocked.length > 0) {
+        actions.push({
+          kind: "warning",
+          title: "Unblock blocked tasks",
+          body: blocked.slice(0, 3).map(task => task.id).join(", ") + " need dependency or review follow-up."
+        });
+      }
+
+      const ready = tasks.filter(task => task.current_state === "pending" && (!task.dependencies || task.dependencies.length === 0));
+      if (ready.length > 0) {
+        actions.push({
+          kind: "info",
+          title: "Start a ready task",
+          body: ready.slice(0, 3).map(task => task.id + " — " + task.title).join(" | ")
+        });
+      }
+
+      if (actions.length === 0) {
+        actions.push({
+          kind: "info",
+          title: "No urgent action",
+          body: "The ledger looks stable. Review in-progress work or wait for the next task to become dispatchable."
+        });
+      }
+
+      document.getElementById("next-actions").innerHTML = actions.map(action => (
+        '<li class="action-item">' +
+          '<div class="action-label ' + action.kind + '">' + escapeHtml(action.kind) + '</div>' +
+          '<div class="task-title">' + escapeHtml(action.title) + '</div>' +
+          '<div class="task-meta">' + escapeHtml(action.body) + '</div>' +
+        '</li>'
+      )).join("");
+    }
+
+    function renderQueues(tasks, validation) {
+      const ready = tasks.filter(task => task.current_state === "pending");
+      const attention = tasks.filter(task =>
+        task.current_state === "blocked" ||
+        task.current_state === "failed" ||
+        task.current_state === "awaiting_github_sync"
+      );
+      const progress = tasks.filter(task => ACTIVE_STATES.has(task.current_state));
+
+      renderTaskList("queue-ready", ready.slice(0, 6), "No ready tasks");
+      renderTaskList("queue-attention", attention.slice(0, 6), validation.severity === "error" ? "Validation has the main issue right now" : "No tasks need attention");
+      renderTaskList("queue-progress", progress.slice(0, 6), "No work in progress");
+    }
+
+    function renderValidationDetail(report) {
+      const details = [];
+      for (const item of report.orphaned_locks || []) details.push("orphaned lock: " + item);
+      for (const item of report.invalid_transitions || []) details.push("invalid transition: " + item);
+      for (const item of report.circular_dependencies || []) details.push("cycle: " + item);
+      for (const item of report.warnings || []) details.push("warning: " + item);
+      renderDetailList("validation-detail", details, "No validation issues");
     }
 
     async function refresh() {
       try {
-        const [statusRes, locksRes, dagRes] = await Promise.all([
-          fetch("/api/status"),
+        const [tasksRes, statsRes, validateRes, locksRes, dagRes] = await Promise.all([
+          fetch("/api/tasks"),
+          fetch("/api/stats"),
+          fetch("/api/validate"),
           fetch("/api/locks"),
           fetch("/api/dag")
         ]);
 
-        if (!statusRes.ok || !locksRes.ok || !dagRes.ok) {
+        if (!tasksRes.ok || !statsRes.ok || !validateRes.ok || !locksRes.ok || !dagRes.ok) {
           throw new Error("API request failed");
         }
 
-        const [status, locks, dag] = await Promise.all([
-          statusRes.json(),
+        const [snapshot, stats, validation, locks, dag] = await Promise.all([
+          tasksRes.json(),
+          statsRes.json(),
+          validateRes.json(),
           locksRes.json(),
           dagRes.json()
         ]);
 
-        renderStats(status);
-        renderTasks(status);
-        renderLocks(locks);
+        const tasks = Array.isArray(snapshot.tasks) ? snapshot.tasks : [];
+        const dispatchableCount = tasks.filter(task => task.current_state === "pending").length;
+        const issueCount = validationIssueCount(validation);
+
+        setHeroStatus(validation.severity || "clean", issueCount, dispatchableCount);
+        renderMetrics(stats, locks, dispatchableCount, issueCount);
+        renderHealth(stats, validation, tasks, locks);
+        renderNextActions(tasks, validation, locks);
+        renderQueues(tasks, validation);
+        renderLockList(locks);
+        renderValidationDetail(validation);
         renderDag(dag);
 
         document.getElementById("meta").textContent =
-          "Snapshot version " + status.version + " | updated " + status.generated_at +
-          " | auto-refresh every 3s";
+          "Snapshot version " + snapshot.version +
+          " · updated " + snapshot.generated_at +
+          " · auto-refresh every 3s";
       } catch (error) {
+        document.getElementById("hero-status").className = "hero-status error";
+        document.getElementById("hero-status").textContent = "Dashboard Unavailable";
         document.getElementById("meta").textContent = "Refresh failed: " + error.message;
-        document.getElementById("stats").innerHTML = '<span class="empty">Failed to load</span>';
-        setEmpty("tasks", "Failed to load tasks");
-        setEmpty("dag", "Failed to load DAG");
-        setEmpty("locks", "Failed to load locks");
+        document.getElementById("health-summary").textContent = "Dashboard data could not be loaded.";
+        document.getElementById("health-pills").innerHTML = "";
+        setListEmpty("next-actions", "Failed to load actions");
+        setListEmpty("queue-ready", "Failed to load tasks");
+        setListEmpty("queue-attention", "Failed to load tasks");
+        setListEmpty("queue-progress", "Failed to load tasks");
+        setListEmpty("locks", "Failed to load locks");
+        setListEmpty("validation-detail", "Failed to load validation");
+        setListEmpty("dag", "Failed to load DAG");
       }
     }
 
@@ -2596,7 +3115,8 @@ fn serve_dashboard(store_path: &std::path::Path, port: u16) -> anyhow::Result<()
     for stream in listener.incoming() {
         match stream {
             Ok(mut stream) => {
-                if let Err(error) = handle_dashboard_connection(&protocol, &mut stream) {
+                if let Err(error) = handle_dashboard_connection(&protocol, store_path, &mut stream)
+                {
                     eprintln!("dashboard request error: {error}");
                 }
             }
@@ -2609,6 +3129,7 @@ fn serve_dashboard(store_path: &std::path::Path, port: u16) -> anyhow::Result<()
 
 fn handle_dashboard_connection(
     protocol: &miyabi_core::protocol::DeterministicExecutionProtocol,
+    store_path: &std::path::Path,
     stream: &mut TcpStream,
 ) -> anyhow::Result<()> {
     let mut request_line = String::new();
@@ -2636,9 +3157,20 @@ fn handle_dashboard_connection(
             "text/html; charset=utf-8",
             POLARIS_DASHBOARD_HTML.as_bytes(),
         )?,
-        "/api/status" => {
+        "/api/tasks" | "/api/status" => {
             let body =
-                serde_json::to_vec_pretty(&protocol.status(None)?).map_err(io::Error::other)?;
+                serde_json::to_vec_pretty(&load_snapshot(store_path)?).map_err(io::Error::other)?;
+            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+        }
+        "/api/stats" => {
+            let stats = miyabi_core::stats::compute_stats(&load_snapshot(store_path)?);
+            let body = serde_json::to_vec_pretty(&stats).map_err(io::Error::other)?;
+            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+        }
+        "/api/validate" => {
+            let report = miyabi_core::validate::validate_snapshot(&load_snapshot(store_path)?);
+            let body = serde_json::to_vec_pretty(&validation_report_json(&report))
+                .map_err(io::Error::other)?;
             write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
         }
         "/api/locks" => {
@@ -2741,5 +3273,104 @@ fn bus_enqueue(task_id: &str, title: &str, store_path: &std::path::Path) {
                 serde_json::to_string(&entry).unwrap_or_default()
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use miyabi_core::store::{ExecutionTask, TaskState, TasksSnapshot};
+    use miyabi_core::validate::validate_snapshot;
+
+    #[test]
+    fn parse_export_since_accepts_rfc3339_and_date_only() {
+        assert_eq!(
+            parse_export_since("2026-04-12T09:30:00Z").unwrap(),
+            Utc.with_ymd_and_hms(2026, 4, 12, 9, 30, 0).unwrap()
+        );
+        assert_eq!(
+            parse_export_since("2026-04-12").unwrap(),
+            Utc.with_ymd_and_hms(2026, 4, 12, 0, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_export_filter_returns_none_when_empty() {
+        let filter = parse_export_filter(ExportFilterArgs {
+            state: None,
+            risk: None,
+            since: None,
+        })
+        .unwrap();
+
+        assert!(filter.is_none());
+    }
+
+    #[test]
+    fn validate_returns_warning_exit_code_for_missing_dependency_reference() {
+        let path = write_snapshot(TasksSnapshot {
+            tasks: vec![task_with_missing_dependency("task-a")],
+            ..TasksSnapshot::default()
+        });
+
+        let code =
+            handle_gate_command(&OutputFormat::Json, false, &path, GateCommand::Validate).unwrap();
+
+        assert_eq!(code, 1);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn validate_returns_error_exit_code_for_invalid_transition() {
+        let path = write_snapshot(TasksSnapshot {
+            tasks: vec![{
+                let mut task = ExecutionTask::new("task-a", "Task A");
+                task.current_state = TaskState::Implementing;
+                task
+            }],
+            ..TasksSnapshot::default()
+        });
+
+        let code =
+            handle_gate_command(&OutputFormat::Json, false, &path, GateCommand::Validate).unwrap();
+
+        assert_eq!(code, 2);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn validation_report_json_includes_severity_and_exit_code() {
+        let report = validate_snapshot(&TasksSnapshot {
+            tasks: vec![{
+                let mut task = ExecutionTask::new("task-a", "Task A");
+                task.current_state = TaskState::Implementing;
+                task
+            }],
+            ..TasksSnapshot::default()
+        });
+
+        let value = validation_report_json(&report);
+
+        assert_eq!(value["severity"], "error");
+        assert_eq!(value["exit_code"], 2);
+        assert!(value["invalid_transitions"].is_array());
+    }
+
+    fn write_snapshot(snapshot: TasksSnapshot) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("mergegate-test-{unique}.json"));
+        std::fs::write(&path, serde_json::to_vec_pretty(&snapshot).unwrap()).unwrap();
+        path
+    }
+
+    fn task_with_missing_dependency(id: &str) -> ExecutionTask {
+        let mut task = ExecutionTask::new(id, "Task A");
+        task.dependencies = vec!["missing-task".to_string()];
+        task.current_state = TaskState::Pending;
+        task
     }
 }

--- a/crates/mergegate-cli/src/main.rs
+++ b/crates/mergegate-cli/src/main.rs
@@ -2440,11 +2440,19 @@ cargo clippy --all-targets --all-features -- -D warnings
   {{GATE}} heartbeat --all
 
 ### serve
-  Start web dashboard.
+  Start the MergeGate-native web dashboard.
   {{GATE}} serve
   {{GATE}} serve --port 8080
   Options:
     --port <N>               Port number (default: 4848)
+  Surfaces:
+    Gate Overview            Validation + next actions + ready queues
+    Task Ledger              Filter by state/risk/since and inspect task detail
+    Dependency Map           DAG levels, blocked chain, dispatchable frontier
+  Static asset order:
+    1. MERGEGATE_DASHBOARD_STATIC_DIR
+    2. web/dashboard/dist
+    3. Embedded Rust-owned fallback
 
 ### guide
   Print this guide.
@@ -2455,6 +2463,7 @@ cargo clippy --all-targets --all-features -- -D warnings
   --store-path <PATH>        Path to tasks.json (default: project_memory/tasks.json)
 "#;
 
+#[allow(dead_code)]
 const POLARIS_DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -3134,6 +3143,8 @@ const POLARIS_DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
 </html>
 "##;
 
+const EMBEDDED_DASHBOARD_HTML: &str = include_str!("dashboard_embedded.html");
+
 fn serve_dashboard(store_path: &std::path::Path, port: u16) -> anyhow::Result<()> {
     let protocol = miyabi_core::protocol::DeterministicExecutionProtocol::from_store_path(
         store_path.to_path_buf(),
@@ -3207,7 +3218,7 @@ fn build_dashboard_response(
         "/api/tasks" => {
             let snapshot = load_snapshot(store_path)?;
             let filter = parse_dashboard_filter(raw_path)?;
-            let body = serde_json::to_vec_pretty(&miyabi_core::export::export_payload(
+            let body = serde_json::to_vec_pretty(&miyabi_core::dashboard_tasks_response(
                 &snapshot,
                 filter.as_ref(),
             ))
@@ -3215,32 +3226,39 @@ fn build_dashboard_response(
             Ok(json_response(body))
         }
         "/api/status" => {
-            let body =
-                serde_json::to_vec_pretty(&load_snapshot(store_path)?).map_err(io::Error::other)?;
+            let snapshot = load_snapshot(store_path)?;
+            let body = serde_json::to_vec_pretty(&miyabi_core::dashboard_status_response(
+                &snapshot,
+            ))
+            .map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         "/api/stats" => {
-            let stats = miyabi_core::stats::compute_stats(&load_snapshot(store_path)?);
+            let snapshot = load_snapshot(store_path)?;
+            let stats = miyabi_core::dashboard_stats_response(&snapshot);
             let body = serde_json::to_vec_pretty(&stats).map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         "/api/validate" => {
-            let report = miyabi_core::validate::validate_snapshot(&load_snapshot(store_path)?);
-            let body =
-                serde_json::to_vec_pretty(&report.to_json_report()).map_err(io::Error::other)?;
+            let snapshot = load_snapshot(store_path)?;
+            let report = miyabi_core::dashboard_validate_response(&snapshot);
+            let body = serde_json::to_vec_pretty(&report).map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         "/api/locks" => {
-            let body = serde_json::to_vec_pretty(&protocol.locks()?).map_err(io::Error::other)?;
+            let body = serde_json::to_vec_pretty(&miyabi_core::dashboard_locks_response(protocol)?)
+                .map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         "/api/dag" => {
-            let body = serde_json::to_vec_pretty(&protocol.dag()?).map_err(io::Error::other)?;
+            let body = serde_json::to_vec_pretty(&miyabi_core::dashboard_dag_response(protocol)?)
+                .map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         "/api/dispatchable" => {
             let body =
-                serde_json::to_vec_pretty(&protocol.dispatchable()?).map_err(io::Error::other)?;
+                serde_json::to_vec_pretty(&miyabi_core::dashboard_dispatchable_response(protocol)?)
+                    .map_err(io::Error::other)?;
             Ok(json_response(body))
         }
         _ if path.starts_with("/api/task/") => task_detail_response(protocol, path),
@@ -3275,14 +3293,16 @@ fn task_detail_response(
         return Ok(text_response("404 Not Found", "not found"));
     };
 
-    match protocol.status(Some(task_id))? {
-        miyabi_core::protocol::StatusReport::Task(task) => {
+    match miyabi_core::dashboard_task_detail_response(protocol, task_id) {
+        Ok(Some(task)) => {
             let body = serde_json::to_vec_pretty(&task).map_err(io::Error::other)?;
             Ok(json_response(body))
         }
-        miyabi_core::protocol::StatusReport::Snapshot(_) => {
+        Ok(None) => Ok(text_response("404 Not Found", "not found")),
+        Err(miyabi_core::protocol::ProtocolError::Input(_)) => {
             Ok(text_response("404 Not Found", "not found"))
         }
+        Err(error) => Err(anyhow::anyhow!(error)),
     }
 }
 
@@ -3311,15 +3331,19 @@ fn static_dashboard_response(store_path: &Path, path: &str) -> anyhow::Result<Da
         return Ok(text_response("404 Not Found", "not found"));
     }
 
-    if path == "/" {
-        return Ok(DashboardResponse {
-            status: "200 OK".to_string(),
-            content_type: "text/html; charset=utf-8".to_string(),
-            body: POLARIS_DASHBOARD_HTML.as_bytes().to_vec(),
-        });
+    if should_fallback_to_dashboard_index(path) {
+        return Ok(embedded_dashboard_response());
     }
 
     Ok(text_response("404 Not Found", "not found"))
+}
+
+fn embedded_dashboard_response() -> DashboardResponse {
+    DashboardResponse {
+        status: "200 OK".to_string(),
+        content_type: "text/html; charset=utf-8".to_string(),
+        body: EMBEDDED_DASHBOARD_HTML.as_bytes().to_vec(),
+    }
 }
 
 fn dashboard_static_dir(store_path: &Path) -> Option<PathBuf> {
@@ -3596,6 +3620,45 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_locks_and_dag_endpoints_expose_expected_shapes() {
+        let fixture = DashboardFixture::new();
+        fixture.register_task("task-a", "Task A");
+        let files = vec!["src/lib.rs".to_string()];
+
+        let lock = fixture
+            .protocol
+            .assign("task-a", "tester", "node", &files)
+            .unwrap()
+            .lock_conflict;
+
+        assert!(!lock.conflicting);
+
+        let locks_response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/api/locks",
+        )
+        .unwrap();
+        let dag_response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/api/dag",
+        )
+        .unwrap();
+
+        let locks: serde_json::Value = serde_json::from_slice(&locks_response.body).unwrap();
+        let dag: serde_json::Value = serde_json::from_slice(&dag_response.body).unwrap();
+
+        assert_eq!(locks_response.status, "200 OK");
+        assert_eq!(locks["src/lib.rs"]["task_id"], "task-a");
+        assert_eq!(locks["src/lib.rs"]["agent"], "tester");
+        assert_eq!(dag_response.status, "200 OK");
+        assert_eq!(dag["levels"][0][0], "task-a");
+    }
+
+    #[test]
     fn dashboard_task_detail_endpoint_returns_registered_task() {
         let fixture = DashboardFixture::new();
         fixture.register_task("task-a", "Task A");
@@ -3613,6 +3676,38 @@ mod tests {
         assert_eq!(value["id"], "task-a");
         assert_eq!(value["title"], "Task A");
         assert_eq!(value["current_state"], "pending");
+    }
+
+    #[test]
+    fn dashboard_task_detail_endpoint_returns_404_for_missing_task() {
+        let fixture = DashboardFixture::new();
+
+        let response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/api/task/missing-task",
+        )
+        .unwrap();
+
+        assert_eq!(response.status, "404 Not Found");
+        assert_eq!(String::from_utf8(response.body).unwrap(), "not found");
+    }
+
+    #[test]
+    fn dashboard_rejects_non_get_requests() {
+        let fixture = DashboardFixture::new();
+
+        let response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "POST",
+            "/api/tasks",
+        )
+        .unwrap();
+
+        assert_eq!(response.status, "405 Method Not Allowed");
+        assert_eq!(String::from_utf8(response.body).unwrap(), "method not allowed");
     }
 
     #[test]
@@ -3651,6 +3746,29 @@ mod tests {
             String::from_utf8(spa_response.body).unwrap(),
             "<html>gate</html>"
         );
+    }
+
+    #[test]
+    fn dashboard_embedded_fallback_serves_shell_without_static_dir() {
+        let fixture = DashboardFixture::new();
+
+        let root_response =
+            build_dashboard_response(&fixture.protocol, &fixture.store_path, "GET", "/").unwrap();
+        let route_response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/ledger",
+        )
+        .unwrap();
+
+        let root_html = String::from_utf8(root_response.body).unwrap();
+        let route_html = String::from_utf8(route_response.body).unwrap();
+
+        assert_eq!(root_response.status, "200 OK");
+        assert!(root_html.contains("Gate Overview, Ledger, and Dependency Map"));
+        assert_eq!(route_response.status, "200 OK");
+        assert!(route_html.contains("Gate Overview, Ledger, and Dependency Map"));
     }
 
     fn write_snapshot(snapshot: TasksSnapshot) -> PathBuf {

--- a/crates/mergegate-cli/src/main.rs
+++ b/crates/mergegate-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
 
@@ -1402,7 +1402,7 @@ fn handle_gate_command(
                 } else if matches!(format, OutputFormat::Json) {
                     println!(
                         "{}",
-                        serde_json::to_string_pretty(&validation_report_json(&report)).unwrap()
+                        serde_json::to_string_pretty(&report.to_json_report()).unwrap()
                     );
                 } else {
                     println!("{report}");
@@ -1574,20 +1574,7 @@ fn load_snapshot(
 fn parse_export_filter(
     args: ExportFilterArgs,
 ) -> anyhow::Result<Option<miyabi_core::export::ExportFilter>> {
-    if args.state.is_none() && args.risk.is_none() && args.since.is_none() {
-        return Ok(None);
-    }
-
-    let since = args.since.as_deref().map(parse_export_since).transpose()?;
-
-    Ok(Some(miyabi_core::export::ExportFilter {
-        // TaskState serialises as snake_case; normalise to lowercase so users can pass
-        // either "Implementing" or "implementing" interchangeably.
-        state: args.state.map(|s| s.to_ascii_lowercase()),
-        // ImpactRiskLevel serialises as SCREAMING_SNAKE_CASE; normalise to uppercase.
-        risk_level: args.risk.map(|r| r.to_ascii_uppercase()),
-        since,
-    }))
+    parse_export_filter_parts(args.state, args.risk, args.since)
 }
 
 fn parse_export_since(value: &str) -> anyhow::Result<DateTime<Utc>> {
@@ -1600,15 +1587,54 @@ fn parse_export_since(value: &str) -> anyhow::Result<DateTime<Utc>> {
     Ok(parsed)
 }
 
-fn validation_report_json(report: &miyabi_core::validate::ValidationReport) -> serde_json::Value {
-    serde_json::json!({
-        "severity": report.severity(),
-        "exit_code": report.exit_code(),
-        "orphaned_locks": report.orphaned_locks,
-        "invalid_transitions": report.invalid_transitions,
-        "circular_dependencies": report.circular_dependencies,
-        "warnings": report.warnings,
-    })
+fn parse_export_filter_parts(
+    state: Option<String>,
+    risk: Option<String>,
+    since: Option<String>,
+) -> anyhow::Result<Option<miyabi_core::export::ExportFilter>> {
+    if state.is_none() && risk.is_none() && since.is_none() {
+        return Ok(None);
+    }
+
+    let since = since.as_deref().map(parse_export_since).transpose()?;
+
+    Ok(Some(miyabi_core::export::ExportFilter {
+        // TaskState serialises as snake_case; normalise to lowercase so users can pass
+        // either "Implementing" or "implementing" interchangeably.
+        state: state.map(|s| s.to_ascii_lowercase()),
+        // ImpactRiskLevel serialises as SCREAMING_SNAKE_CASE; normalise to uppercase.
+        risk_level: risk.map(|r| r.to_ascii_uppercase()),
+        since,
+    }))
+}
+
+fn parse_query_string(query: &str) -> HashMap<String, String> {
+    query
+        .split('&')
+        .filter(|entry| !entry.is_empty())
+        .filter_map(|entry| {
+            let (key, value) = entry.split_once('=').unwrap_or((entry, ""));
+            if key.is_empty() {
+                None
+            } else {
+                Some((key.to_string(), value.to_string()))
+            }
+        })
+        .collect()
+}
+
+fn parse_dashboard_filter(path: &str) -> anyhow::Result<Option<miyabi_core::export::ExportFilter>> {
+    let query = path.split_once('?').map(|(_, query)| query);
+    let Some(query) = query else {
+        return Ok(None);
+    };
+
+    let params = parse_query_string(query);
+    parse_export_filter_parts(
+        params.get("state").cloned(),
+        params.get("risk").cloned(),
+        params.get("since").cloned(),
+    )
 }
 
 fn build_assign_execution_plan(
@@ -3141,58 +3167,215 @@ fn handle_dashboard_connection(
 
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or_default();
-    let path = parts.next().unwrap_or("/");
+    let raw_path = parts.next().unwrap_or("/");
+    let response = build_dashboard_response(protocol, store_path, method, raw_path)?;
+    write_http_response(
+        stream,
+        &response.status,
+        &response.content_type,
+        &response.body,
+    )?;
+
+    Ok(())
+}
+
+struct DashboardResponse {
+    status: String,
+    content_type: String,
+    body: Vec<u8>,
+}
+
+fn build_dashboard_response(
+    protocol: &miyabi_core::protocol::DeterministicExecutionProtocol,
+    store_path: &Path,
+    method: &str,
+    raw_path: &str,
+) -> anyhow::Result<DashboardResponse> {
+    let path = raw_path
+        .split_once('?')
+        .map(|(path, _)| path)
+        .unwrap_or(raw_path);
 
     if method != "GET" {
-        write_http_response(
-            stream,
+        return Ok(text_response(
             "405 Method Not Allowed",
-            "text/plain; charset=utf-8",
-            b"method not allowed",
-        )?;
-        return Ok(());
+            "method not allowed",
+        ));
     }
 
     match path {
-        "/" => write_http_response(
-            stream,
-            "200 OK",
-            "text/html; charset=utf-8",
-            POLARIS_DASHBOARD_HTML.as_bytes(),
-        )?,
-        "/api/tasks" | "/api/status" => {
+        "/api/tasks" => {
+            let snapshot = load_snapshot(store_path)?;
+            let filter = parse_dashboard_filter(raw_path)?;
+            let body = serde_json::to_vec_pretty(&miyabi_core::export::export_payload(
+                &snapshot,
+                filter.as_ref(),
+            ))
+            .map_err(io::Error::other)?;
+            Ok(json_response(body))
+        }
+        "/api/status" => {
             let body =
                 serde_json::to_vec_pretty(&load_snapshot(store_path)?).map_err(io::Error::other)?;
-            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+            Ok(json_response(body))
         }
         "/api/stats" => {
             let stats = miyabi_core::stats::compute_stats(&load_snapshot(store_path)?);
             let body = serde_json::to_vec_pretty(&stats).map_err(io::Error::other)?;
-            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+            Ok(json_response(body))
         }
         "/api/validate" => {
             let report = miyabi_core::validate::validate_snapshot(&load_snapshot(store_path)?);
-            let body = serde_json::to_vec_pretty(&validation_report_json(&report))
-                .map_err(io::Error::other)?;
-            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+            let body =
+                serde_json::to_vec_pretty(&report.to_json_report()).map_err(io::Error::other)?;
+            Ok(json_response(body))
         }
         "/api/locks" => {
             let body = serde_json::to_vec_pretty(&protocol.locks()?).map_err(io::Error::other)?;
-            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+            Ok(json_response(body))
         }
         "/api/dag" => {
             let body = serde_json::to_vec_pretty(&protocol.dag()?).map_err(io::Error::other)?;
-            write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body)?;
+            Ok(json_response(body))
         }
-        _ => write_http_response(
-            stream,
-            "404 Not Found",
-            "text/plain; charset=utf-8",
-            b"not found",
-        )?,
+        "/api/dispatchable" => {
+            let body =
+                serde_json::to_vec_pretty(&protocol.dispatchable()?).map_err(io::Error::other)?;
+            Ok(json_response(body))
+        }
+        _ if path.starts_with("/api/task/") => task_detail_response(protocol, path),
+        _ => static_dashboard_response(store_path, path),
+    }
+}
+
+fn json_response(body: Vec<u8>) -> DashboardResponse {
+    DashboardResponse {
+        status: "200 OK".to_string(),
+        content_type: "application/json; charset=utf-8".to_string(),
+        body,
+    }
+}
+
+fn text_response(status: &str, body: &str) -> DashboardResponse {
+    DashboardResponse {
+        status: status.to_string(),
+        content_type: "text/plain; charset=utf-8".to_string(),
+        body: body.as_bytes().to_vec(),
+    }
+}
+
+fn task_detail_response(
+    protocol: &miyabi_core::protocol::DeterministicExecutionProtocol,
+    path: &str,
+) -> anyhow::Result<DashboardResponse> {
+    let Some(task_id) = path
+        .strip_prefix("/api/task/")
+        .filter(|task_id| !task_id.is_empty())
+    else {
+        return Ok(text_response("404 Not Found", "not found"));
+    };
+
+    match protocol.status(Some(task_id))? {
+        miyabi_core::protocol::StatusReport::Task(task) => {
+            let body = serde_json::to_vec_pretty(&task).map_err(io::Error::other)?;
+            Ok(json_response(body))
+        }
+        miyabi_core::protocol::StatusReport::Snapshot(_) => {
+            Ok(text_response("404 Not Found", "not found"))
+        }
+    }
+}
+
+fn static_dashboard_response(store_path: &Path, path: &str) -> anyhow::Result<DashboardResponse> {
+    if let Some(static_dir) = dashboard_static_dir(store_path) {
+        if let Some(file_path) = dashboard_asset_path(&static_dir, path) {
+            let body = fs::read(&file_path)?;
+            return Ok(DashboardResponse {
+                status: "200 OK".to_string(),
+                content_type: dashboard_content_type(&file_path).to_string(),
+                body,
+            });
+        }
+
+        if should_fallback_to_dashboard_index(path) {
+            let index_path = static_dir.join("index.html");
+            if index_path.exists() {
+                return Ok(DashboardResponse {
+                    status: "200 OK".to_string(),
+                    content_type: "text/html; charset=utf-8".to_string(),
+                    body: fs::read(index_path)?,
+                });
+            }
+        }
+
+        return Ok(text_response("404 Not Found", "not found"));
     }
 
-    Ok(())
+    if path == "/" {
+        return Ok(DashboardResponse {
+            status: "200 OK".to_string(),
+            content_type: "text/html; charset=utf-8".to_string(),
+            body: POLARIS_DASHBOARD_HTML.as_bytes().to_vec(),
+        });
+    }
+
+    Ok(text_response("404 Not Found", "not found"))
+}
+
+fn dashboard_static_dir(store_path: &Path) -> Option<PathBuf> {
+    if let Some(override_path) = std::env::var_os("MERGEGATE_DASHBOARD_STATIC_DIR") {
+        let path = PathBuf::from(override_path);
+        if path.is_dir() {
+            return Some(path);
+        }
+    }
+
+    let repo_root = store_path
+        .parent()
+        .and_then(|path| path.parent())
+        .unwrap_or_else(|| Path::new("."));
+    let default_path = repo_root.join("web/dashboard/dist");
+    default_path.is_dir().then_some(default_path)
+}
+
+fn dashboard_asset_path(static_dir: &Path, path: &str) -> Option<PathBuf> {
+    let relative = if path == "/" {
+        PathBuf::from("index.html")
+    } else {
+        let stripped = path.trim_start_matches('/');
+        let mut relative = PathBuf::new();
+        for component in Path::new(stripped).components() {
+            match component {
+                Component::Normal(part) => relative.push(part),
+                Component::CurDir => {}
+                Component::ParentDir | Component::Prefix(_) | Component::RootDir => return None,
+            }
+        }
+        relative
+    };
+
+    let candidate = static_dir.join(relative);
+    candidate.is_file().then_some(candidate)
+}
+
+fn should_fallback_to_dashboard_index(path: &str) -> bool {
+    path == "/" || !path.rsplit('/').next().unwrap_or_default().contains('.')
+}
+
+fn dashboard_content_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("html") => "text/html; charset=utf-8",
+        Some("js") => "application/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("svg") => "image/svg+xml",
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("ico") => "image/x-icon",
+        Some("woff") => "font/woff",
+        Some("woff2") => "font/woff2",
+        _ => "application/octet-stream",
+    }
 }
 
 fn write_http_response(
@@ -3283,7 +3466,8 @@ fn bus_enqueue(task_id: &str, title: &str, store_path: &std::path::Path) {
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
-    use miyabi_core::store::{ExecutionTask, TaskState, TasksSnapshot};
+    use miyabi_core::protocol::{DeterministicExecutionProtocol, RegisterTaskRequest};
+    use miyabi_core::store::{CompletionMode, ExecutionTask, TaskState, TasksSnapshot};
     use miyabi_core::validate::validate_snapshot;
 
     #[test]
@@ -3324,7 +3508,20 @@ mod tests {
         assert_eq!(filter.risk_level.as_deref(), Some("HIGH"));
     }
 
+    #[test]
+    fn parse_dashboard_filter_reads_same_keys_as_export_commands() {
+        let filter =
+            parse_dashboard_filter("/api/tasks?state=implementing&risk=HIGH&since=2026-04-12")
+                .unwrap()
+                .expect("filter should exist");
 
+        assert_eq!(filter.state.as_deref(), Some("implementing"));
+        assert_eq!(filter.risk_level.as_deref(), Some("HIGH"));
+        assert_eq!(
+            filter.since,
+            Some(Utc.with_ymd_and_hms(2026, 4, 12, 0, 0, 0).unwrap())
+        );
+    }
     #[test]
     fn validate_returns_warning_exit_code_for_missing_dependency_reference() {
         let path = write_snapshot(TasksSnapshot {
@@ -3358,7 +3555,7 @@ mod tests {
     }
 
     #[test]
-    fn validation_report_json_includes_severity_and_exit_code() {
+    fn validation_report_json_includes_fixed_counts() {
         let report = validate_snapshot(&TasksSnapshot {
             tasks: vec![{
                 let mut task = ExecutionTask::new("task-a", "Task A");
@@ -3368,11 +3565,92 @@ mod tests {
             ..TasksSnapshot::default()
         });
 
-        let value = validation_report_json(&report);
+        let value = serde_json::to_value(report.to_json_report()).unwrap();
 
         assert_eq!(value["severity"], "error");
         assert_eq!(value["exit_code"], 2);
+        assert_eq!(value["issue_count"], 1);
+        assert_eq!(value["error_count"], 1);
+        assert_eq!(value["warning_count"], 0);
         assert!(value["invalid_transitions"].is_array());
+    }
+
+    #[test]
+    fn dashboard_dispatchable_endpoint_returns_protocol_owned_payload() {
+        let fixture = DashboardFixture::new();
+        fixture.register_task("task-a", "Task A");
+
+        let response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/api/dispatchable",
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+
+        assert_eq!(response.status, "200 OK");
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["task_ids"][0], "task-a");
+        assert_eq!(value["tasks"][0]["id"], "task-a");
+    }
+
+    #[test]
+    fn dashboard_task_detail_endpoint_returns_registered_task() {
+        let fixture = DashboardFixture::new();
+        fixture.register_task("task-a", "Task A");
+
+        let response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/api/task/task-a",
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+
+        assert_eq!(response.status, "200 OK");
+        assert_eq!(value["id"], "task-a");
+        assert_eq!(value["title"], "Task A");
+        assert_eq!(value["current_state"], "pending");
+    }
+
+    #[test]
+    fn dashboard_static_dir_serves_assets_and_spa_fallback() {
+        let fixture = DashboardFixture::new();
+        let static_dir = fixture.tempdir.path().join("dist");
+        std::fs::create_dir_all(static_dir.join("assets")).unwrap();
+        std::fs::write(static_dir.join("index.html"), "<html>gate</html>").unwrap();
+        std::fs::write(static_dir.join("assets/app.js"), "console.log('gate');").unwrap();
+        let _guard = EnvVarGuard::set("MERGEGATE_DASHBOARD_STATIC_DIR", &static_dir);
+
+        let asset_response = build_dashboard_response(
+            &fixture.protocol,
+            &fixture.store_path,
+            "GET",
+            "/assets/app.js",
+        )
+        .unwrap();
+        let spa_response =
+            build_dashboard_response(&fixture.protocol, &fixture.store_path, "GET", "/tasks")
+                .unwrap();
+
+        assert_eq!(asset_response.status, "200 OK");
+        assert_eq!(
+            asset_response.content_type,
+            "application/javascript; charset=utf-8"
+        );
+        assert_eq!(
+            String::from_utf8(asset_response.body).unwrap(),
+            "console.log('gate');"
+        );
+
+        assert_eq!(spa_response.status, "200 OK");
+        assert_eq!(spa_response.content_type, "text/html; charset=utf-8");
+        assert_eq!(
+            String::from_utf8(spa_response.body).unwrap(),
+            "<html>gate</html>"
+        );
     }
 
     fn write_snapshot(snapshot: TasksSnapshot) -> PathBuf {
@@ -3390,5 +3668,97 @@ mod tests {
         task.dependencies = vec!["missing-task".to_string()];
         task.current_state = TaskState::Pending;
         task
+    }
+
+    struct DashboardFixture {
+        tempdir: TestTempDir,
+        store_path: PathBuf,
+        protocol: DeterministicExecutionProtocol,
+    }
+
+    impl DashboardFixture {
+        fn new() -> Self {
+            let tempdir = TestTempDir::new();
+            let store_path = tempdir.path().join("project_memory/tasks.json");
+            std::fs::create_dir_all(store_path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &store_path,
+                serde_json::to_vec_pretty(&TasksSnapshot::default()).unwrap(),
+            )
+            .unwrap();
+            let protocol = DeterministicExecutionProtocol::from_store_path(store_path.clone());
+            Self {
+                tempdir,
+                store_path,
+                protocol,
+            }
+        }
+
+        fn register_task(&self, task_id: &str, title: &str) {
+            self.protocol
+                .register(
+                    RegisterTaskRequest {
+                        issue: 0,
+                        task_id: task_id.to_string(),
+                        title: title.to_string(),
+                        dependencies: Vec::new(),
+                        soft_dependencies: Vec::new(),
+                        priority: 1,
+                        completion_mode: CompletionMode::Manual,
+                    },
+                    "tester",
+                    "node",
+                )
+                .unwrap();
+        }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.original {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new() -> Self {
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("mergegate-cli-test-{unique}"));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.path).ok();
+        }
     }
 }

--- a/crates/mergegate-core/src/dashboard.rs
+++ b/crates/mergegate-core/src/dashboard.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use crate::export::{export_payload, ExportFilter, ExportedTasksPayload};
+use crate::protocol::{DagReport, DeterministicExecutionProtocol, DispatchableReport, StatusReport};
+use crate::stats::{compute_stats, TaskStats};
+use crate::store::{ExecutionTask, FileLockEntry, TasksSnapshot};
+use crate::validate::{validate_snapshot, ValidationJsonReport};
+
+pub type DashboardTasksResponse = ExportedTasksPayload;
+pub type DashboardStatusResponse = TasksSnapshot;
+pub type DashboardStatsResponse = TaskStats;
+pub type DashboardValidateResponse = ValidationJsonReport;
+pub type DashboardLocksResponse = HashMap<String, FileLockEntry>;
+pub type DashboardDagResponse = DagReport;
+pub type DashboardDispatchableResponse = DispatchableReport;
+pub type DashboardTaskDetailResponse = ExecutionTask;
+
+pub fn tasks_response(
+    snapshot: &TasksSnapshot,
+    filter: Option<&ExportFilter>,
+) -> DashboardTasksResponse {
+    export_payload(snapshot, filter)
+}
+
+pub fn status_response(snapshot: &TasksSnapshot) -> DashboardStatusResponse {
+    snapshot.clone()
+}
+
+pub fn stats_response(snapshot: &TasksSnapshot) -> DashboardStatsResponse {
+    compute_stats(snapshot)
+}
+
+pub fn validate_response(snapshot: &TasksSnapshot) -> DashboardValidateResponse {
+    validate_snapshot(snapshot).to_json_report()
+}
+
+pub fn locks_response(
+    protocol: &DeterministicExecutionProtocol,
+) -> crate::protocol::ProtocolResult<DashboardLocksResponse> {
+    protocol.locks()
+}
+
+pub fn dag_response(
+    protocol: &DeterministicExecutionProtocol,
+) -> crate::protocol::ProtocolResult<DashboardDagResponse> {
+    protocol.dag()
+}
+
+pub fn dispatchable_response(
+    protocol: &DeterministicExecutionProtocol,
+) -> crate::protocol::ProtocolResult<DashboardDispatchableResponse> {
+    protocol.dispatchable()
+}
+
+pub fn task_detail_response(
+    protocol: &DeterministicExecutionProtocol,
+    task_id: &str,
+) -> crate::protocol::ProtocolResult<Option<DashboardTaskDetailResponse>> {
+    match protocol.status(Some(task_id))? {
+        StatusReport::Task(task) => Ok(Some(*task)),
+        StatusReport::Snapshot(_) => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::{DeterministicExecutionProtocol, RegisterTaskRequest};
+    use crate::store::{CompletionMode, TaskState, TasksSnapshot};
+
+    use super::{
+        dag_response, dispatchable_response, stats_response, task_detail_response, tasks_response,
+        validate_response,
+    };
+
+    #[test]
+    fn dashboard_payload_helpers_reuse_snapshot_contracts() {
+        let snapshot = TasksSnapshot::default();
+
+        let tasks = tasks_response(&snapshot, None);
+        let stats = stats_response(&snapshot);
+        let validation = validate_response(&snapshot);
+
+        assert_eq!(tasks.task_count, 0);
+        assert_eq!(stats.total, 0);
+        assert_eq!(validation.issue_count, 0);
+    }
+
+    #[test]
+    fn dashboard_protocol_helpers_return_task_detail_and_dag() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let store_path = tempdir.path().join("project_memory/tasks.json");
+        std::fs::create_dir_all(store_path.parent().unwrap()).unwrap();
+        std::fs::write(&store_path, serde_json::to_vec_pretty(&TasksSnapshot::default()).unwrap())
+            .unwrap();
+        let protocol = DeterministicExecutionProtocol::from_store_path(store_path);
+
+        protocol
+            .register(
+                RegisterTaskRequest {
+                    issue: 0,
+                    task_id: "task-a".to_string(),
+                    title: "Task A".to_string(),
+                    dependencies: Vec::new(),
+                    soft_dependencies: Vec::new(),
+                    priority: 1,
+                    completion_mode: CompletionMode::Manual,
+                },
+                "tester",
+                "node",
+            )
+            .unwrap();
+
+        let task = task_detail_response(&protocol, "task-a")
+            .unwrap()
+            .expect("task exists");
+        let dispatchable = dispatchable_response(&protocol).unwrap();
+        let dag = dag_response(&protocol).unwrap();
+
+        assert_eq!(task.current_state, TaskState::Pending);
+        assert_eq!(dispatchable.count, 1);
+        assert_eq!(dispatchable.task_ids, vec!["task-a".to_string()]);
+        assert_eq!(dag.levels, vec![vec!["task-a".to_string()]]);
+    }
+}

--- a/crates/mergegate-core/src/export.rs
+++ b/crates/mergegate-core/src/export.rs
@@ -1,0 +1,246 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::store::{ExecutionTask, TasksSnapshot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportFilter {
+    pub state: Option<String>,
+    pub risk_level: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExportedTask<'a> {
+    id: &'a str,
+    title: &'a str,
+    state: String,
+    impact_risk: Option<String>,
+    branch: Option<&'a str>,
+    created_at: DateTime<Utc>,
+}
+
+pub fn export_json(snapshot: &TasksSnapshot, filter: Option<ExportFilter>) -> String {
+    let tasks: Vec<ExportedTask<'_>> = filtered_tasks(snapshot, filter.as_ref())
+        .into_iter()
+        .map(ExportedTask::from_task)
+        .collect();
+
+    serde_json::to_string_pretty(&tasks).expect("task export should serialize")
+}
+
+pub fn filtered_tasks<'a>(
+    snapshot: &'a TasksSnapshot,
+    filter: Option<&ExportFilter>,
+) -> Vec<&'a ExecutionTask> {
+    snapshot
+        .tasks
+        .iter()
+        .filter(|task| matches_filter(task, filter))
+        .collect()
+}
+
+pub fn matches_filter(task: &ExecutionTask, filter: Option<&ExportFilter>) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+
+    if let Some(expected_state) = filter.state.as_deref() {
+        if task_state(task) != expected_state {
+            return false;
+        }
+    }
+
+    if let Some(expected_risk) = filter.risk_level.as_deref() {
+        if task_risk(task).as_deref() != Some(expected_risk) {
+            return false;
+        }
+    }
+
+    if let Some(since) = filter.since {
+        if task.created_at < since {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn task_state(task: &ExecutionTask) -> String {
+    serde_json::to_value(task.current_state)
+        .expect("task state should serialize")
+        .as_str()
+        .expect("task state should serialize as string")
+        .to_owned()
+}
+
+fn task_risk(task: &ExecutionTask) -> Option<String> {
+    task.impact.as_ref().map(|impact| {
+        serde_json::to_value(impact.risk_level)
+            .expect("impact risk should serialize")
+            .as_str()
+            .expect("impact risk should serialize as string")
+            .to_owned()
+    })
+}
+
+impl<'a> ExportedTask<'a> {
+    fn from_task(task: &'a ExecutionTask) -> Self {
+        Self {
+            id: &task.id,
+            title: &task.title,
+            state: task_state(task),
+            impact_risk: task_risk(task),
+            branch: task.branch_name.as_deref(),
+            created_at: task.created_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{export_json, ExportFilter};
+    use crate::store::{ExecutionTask, ImpactRiskLevel, TaskImpact, TaskState, TasksSnapshot};
+    use chrono::{Duration, TimeZone, Utc};
+    use serde_json::Value;
+
+    fn sample_task(
+        id: &str,
+        state: TaskState,
+        risk_level: Option<ImpactRiskLevel>,
+        created_at: chrono::DateTime<Utc>,
+    ) -> ExecutionTask {
+        let mut task = ExecutionTask::new(id, format!("Task {id}"));
+        task.current_state = state;
+        task.branch_name = Some(format!("branch/{id}"));
+        task.created_at = created_at;
+        task.updated_at = created_at;
+        task.impact = risk_level.map(|risk_level| TaskImpact {
+            risk_level,
+            affected_symbols: 2,
+            depth1: vec!["src/lib.rs".to_string()],
+            analyzed_at: created_at,
+            analyzed_commit: Some("abc123".to_string()),
+            input_hash: Some("hash".to_string()),
+        });
+        task
+    }
+
+    fn sample_snapshot() -> TasksSnapshot {
+        let base = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        TasksSnapshot {
+            version: 1,
+            generated_at: base + Duration::days(10),
+            generated_from_event_id: Some("event-1".to_string()),
+            tasks: vec![
+                sample_task("task-1", TaskState::Draft, Some(ImpactRiskLevel::Low), base),
+                sample_task(
+                    "task-2",
+                    TaskState::Implementing,
+                    Some(ImpactRiskLevel::High),
+                    base + Duration::days(1),
+                ),
+                sample_task(
+                    "task-3",
+                    TaskState::Done,
+                    Some(ImpactRiskLevel::Critical),
+                    base + Duration::days(2),
+                ),
+            ],
+            file_locks: Default::default(),
+        }
+    }
+
+    fn exported_ids(json: &str) -> Vec<String> {
+        serde_json::from_str::<Vec<Value>>(json)
+            .expect("valid json")
+            .into_iter()
+            .map(|task| {
+                task.get("id")
+                    .and_then(Value::as_str)
+                    .expect("id field")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn exports_all_tasks_without_filter() {
+        let snapshot = sample_snapshot();
+
+        let json = export_json(&snapshot, None);
+        let tasks = serde_json::from_str::<Vec<Value>>(&json).expect("valid json");
+
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0]["id"], "task-1");
+        assert_eq!(tasks[0]["state"], "draft");
+        assert_eq!(tasks[0]["impact_risk"], "LOW");
+        assert_eq!(tasks[0]["branch"], "branch/task-1");
+        assert_eq!(tasks[0]["created_at"], "2026-04-01T00:00:00Z");
+    }
+
+    #[test]
+    fn filters_by_state() {
+        let snapshot = sample_snapshot();
+
+        let json = export_json(
+            &snapshot,
+            Some(ExportFilter {
+                state: Some("implementing".to_string()),
+                risk_level: None,
+                since: None,
+            }),
+        );
+
+        assert_eq!(exported_ids(&json), vec!["task-2"]);
+    }
+
+    #[test]
+    fn filters_by_risk_level() {
+        let snapshot = sample_snapshot();
+
+        let json = export_json(
+            &snapshot,
+            Some(ExportFilter {
+                state: None,
+                risk_level: Some("CRITICAL".to_string()),
+                since: None,
+            }),
+        );
+
+        assert_eq!(exported_ids(&json), vec!["task-3"]);
+    }
+
+    #[test]
+    fn filters_by_creation_date() {
+        let snapshot = sample_snapshot();
+        let since = Utc.with_ymd_and_hms(2026, 4, 2, 0, 0, 0).unwrap();
+
+        let json = export_json(
+            &snapshot,
+            Some(ExportFilter {
+                state: None,
+                risk_level: None,
+                since: Some(since),
+            }),
+        );
+
+        assert_eq!(exported_ids(&json), vec!["task-2", "task-3"]);
+    }
+
+    #[test]
+    fn returns_empty_array_when_no_tasks_match() {
+        let snapshot = sample_snapshot();
+
+        let json = export_json(
+            &snapshot,
+            Some(ExportFilter {
+                state: Some("blocked".to_string()),
+                risk_level: Some("LOW".to_string()),
+                since: None,
+            }),
+        );
+
+        assert_eq!(json, "[]");
+    }
+}

--- a/crates/mergegate-core/src/export.rs
+++ b/crates/mergegate-core/src/export.rs
@@ -1,32 +1,62 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::store::{ExecutionTask, TasksSnapshot};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExportFilter {
     pub state: Option<String>,
     pub risk_level: Option<String>,
     pub since: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Serialize)]
-struct ExportedTask<'a> {
-    id: &'a str,
-    title: &'a str,
-    state: String,
-    impact_risk: Option<String>,
-    branch: Option<&'a str>,
-    created_at: DateTime<Utc>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportedTask {
+    pub id: String,
+    pub title: String,
+    pub state: String,
+    pub current_state: String,
+    pub impact_risk: Option<String>,
+    pub branch: Option<String>,
+    pub dependencies: Vec<String>,
+    pub priority: u32,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportedTasksPayload {
+    pub version: u64,
+    pub generated_at: DateTime<Utc>,
+    pub generated_from_event_id: Option<String>,
+    pub task_count: usize,
+    pub tasks: Vec<ExportedTask>,
 }
 
 pub fn export_json(snapshot: &TasksSnapshot, filter: Option<ExportFilter>) -> String {
-    let tasks: Vec<ExportedTask<'_>> = filtered_tasks(snapshot, filter.as_ref())
-        .into_iter()
-        .map(ExportedTask::from_task)
-        .collect();
+    let tasks = export_tasks(snapshot, filter.as_ref());
 
     serde_json::to_string_pretty(&tasks).expect("task export should serialize")
+}
+
+pub fn export_tasks(snapshot: &TasksSnapshot, filter: Option<&ExportFilter>) -> Vec<ExportedTask> {
+    filtered_tasks(snapshot, filter)
+        .into_iter()
+        .map(ExportedTask::from_task)
+        .collect()
+}
+
+pub fn export_payload(
+    snapshot: &TasksSnapshot,
+    filter: Option<&ExportFilter>,
+) -> ExportedTasksPayload {
+    let tasks = export_tasks(snapshot, filter);
+    ExportedTasksPayload {
+        version: snapshot.version,
+        generated_at: snapshot.generated_at,
+        generated_from_event_id: snapshot.generated_from_event_id.clone(),
+        task_count: tasks.len(),
+        tasks,
+    }
 }
 
 pub fn filtered_tasks<'a>(
@@ -84,14 +114,18 @@ fn task_risk(task: &ExecutionTask) -> Option<String> {
     })
 }
 
-impl<'a> ExportedTask<'a> {
-    fn from_task(task: &'a ExecutionTask) -> Self {
+impl ExportedTask {
+    fn from_task(task: &ExecutionTask) -> Self {
+        let state = task_state(task);
         Self {
-            id: &task.id,
-            title: &task.title,
-            state: task_state(task),
+            id: task.id.clone(),
+            title: task.title.clone(),
+            state: state.clone(),
+            current_state: state,
             impact_risk: task_risk(task),
-            branch: task.branch_name.as_deref(),
+            branch: task.branch_name.clone(),
+            dependencies: task.dependencies.clone(),
+            priority: task.priority,
             created_at: task.created_at,
         }
     }
@@ -99,7 +133,7 @@ impl<'a> ExportedTask<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{export_json, ExportFilter};
+    use super::{export_json, export_payload, ExportFilter};
     use crate::store::{ExecutionTask, ImpactRiskLevel, TaskImpact, TaskState, TasksSnapshot};
     use chrono::{Duration, TimeZone, Utc};
     use serde_json::Value;
@@ -174,6 +208,7 @@ mod tests {
         assert_eq!(tasks.len(), 3);
         assert_eq!(tasks[0]["id"], "task-1");
         assert_eq!(tasks[0]["state"], "draft");
+        assert_eq!(tasks[0]["current_state"], "draft");
         assert_eq!(tasks[0]["impact_risk"], "LOW");
         assert_eq!(tasks[0]["branch"], "branch/task-1");
         assert_eq!(tasks[0]["created_at"], "2026-04-01T00:00:00Z");
@@ -242,5 +277,26 @@ mod tests {
         );
 
         assert_eq!(json, "[]");
+    }
+
+    #[test]
+    fn exports_payload_with_snapshot_metadata() {
+        let snapshot = sample_snapshot();
+
+        let payload = export_payload(
+            &snapshot,
+            Some(&ExportFilter {
+                state: Some("implementing".to_string()),
+                risk_level: None,
+                since: None,
+            }),
+        );
+
+        assert_eq!(payload.version, 1);
+        assert_eq!(payload.generated_at, snapshot.generated_at);
+        assert_eq!(payload.generated_from_event_id.as_deref(), Some("event-1"));
+        assert_eq!(payload.task_count, 1);
+        assert_eq!(payload.tasks[0].id, "task-2");
+        assert_eq!(payload.tasks[0].current_state, "implementing");
     }
 }

--- a/crates/mergegate-core/src/export_md.rs
+++ b/crates/mergegate-core/src/export_md.rs
@@ -26,14 +26,16 @@ pub fn export_markdown(snapshot: &TasksSnapshot, filter: Option<&ExportFilter>) 
     let completed = tasks.iter().filter(|task| is_completed(task)).count();
     let active = tasks.iter().filter(|task| is_active(task)).count();
     let waiting = tasks.iter().filter(|task| is_waiting(task)).count();
+    let failed = tasks.iter().filter(|task| is_failed(task)).count();
 
     lines.push(String::new());
     lines.push(format!(
-        "Total: {} tasks ({} completed, {} active, {} waiting)",
+        "Total: {} tasks ({} completed, {} active, {} waiting, {} failed)",
         tasks.len(),
         completed,
         active,
-        waiting
+        waiting,
+        failed
     ));
 
     lines.join("\n")
@@ -93,6 +95,10 @@ fn is_waiting(task: &ExecutionTask) -> bool {
         task.current_state,
         TaskState::Draft | TaskState::Pending | TaskState::Blocked | TaskState::AwaitingGithubSync
     )
+}
+
+fn is_failed(task: &ExecutionTask) -> bool {
+    matches!(task.current_state, TaskState::Failed)
 }
 
 fn title_case(value: &str) -> String {
@@ -182,7 +188,7 @@ mod tests {
         assert!(markdown.contains(
             "| task-2 | Merge snapshot writer | 🔀 Merged | HIGH | branch/task-2 | 2026-04-10 |"
         ));
-        assert!(markdown.ends_with("Total: 2 tasks (1 completed, 1 active, 0 waiting)"));
+        assert!(markdown.ends_with("Total: 2 tasks (1 completed, 1 active, 0 waiting, 0 failed)"));
     }
 
     #[test]
@@ -191,7 +197,7 @@ mod tests {
 
         assert_eq!(
             markdown,
-            "| ID | Title | State | Risk | Branch | Created |\n| --- | --- | --- | --- | --- | --- |\n\nTotal: 0 tasks (0 completed, 0 active, 0 waiting)"
+            "| ID | Title | State | Risk | Branch | Created |\n| --- | --- | --- | --- | --- | --- |\n\nTotal: 0 tasks (0 completed, 0 active, 0 waiting, 0 failed)"
         );
     }
 
@@ -206,7 +212,7 @@ mod tests {
 
         assert!(markdown
             .contains("| task-1 | Ship feature | ✅ Done | - | branch/task-1 | 2026-04-10 |"));
-        assert!(markdown.ends_with("Total: 1 tasks (1 completed, 0 active, 0 waiting)"));
+        assert!(markdown.ends_with("Total: 1 tasks (1 completed, 0 active, 0 waiting, 0 failed)"));
     }
 
     #[test]
@@ -231,7 +237,7 @@ mod tests {
         assert!(markdown
             .contains("| pending | Pending task | ⏳ Pending | - | branch/pending | 2026-04-10 |"));
         assert!(markdown.contains("| draft | Draft task | Draft | - | branch/draft | 2026-04-10 |"));
-        assert!(markdown.ends_with("Total: 5 tasks (2 completed, 1 active, 2 waiting)"));
+        assert!(markdown.ends_with("Total: 5 tasks (2 completed, 1 active, 2 waiting, 0 failed)"));
     }
 
     #[test]
@@ -281,6 +287,6 @@ mod tests {
 
         assert!(markdown.contains("| task-1 | Implement markdown export |"));
         assert!(!markdown.contains("| task-2 | Ship release |"));
-        assert!(markdown.ends_with("Total: 1 tasks (0 completed, 1 active, 0 waiting)"));
+        assert!(markdown.ends_with("Total: 1 tasks (0 completed, 1 active, 0 waiting, 0 failed)"));
     }
 }

--- a/crates/mergegate-core/src/export_md.rs
+++ b/crates/mergegate-core/src/export_md.rs
@@ -1,0 +1,288 @@
+use crate::export::ExportFilter;
+use crate::store::{ExecutionTask, TaskState, TasksSnapshot};
+
+const TITLE_LIMIT: usize = 48;
+
+pub fn export_markdown(snapshot: &TasksSnapshot, filter: Option<&ExportFilter>) -> String {
+    let mut lines = vec![
+        "| ID | Title | State | Risk | Branch | Created |".to_string(),
+        "| --- | --- | --- | --- | --- | --- |".to_string(),
+    ];
+
+    let tasks = crate::export::filtered_tasks(snapshot, filter);
+
+    for task in &tasks {
+        lines.push(format!(
+            "| {} | {} | {} | {} | {} | {} |",
+            escape_cell(&task.id),
+            escape_cell(&truncate_title(&task.title)),
+            format_state(task),
+            format_risk(task),
+            escape_cell(task.branch_name.as_deref().unwrap_or("-")),
+            task.created_at.format("%Y-%m-%d"),
+        ));
+    }
+
+    let completed = tasks.iter().filter(|task| is_completed(task)).count();
+    let active = tasks.iter().filter(|task| is_active(task)).count();
+    let waiting = tasks.iter().filter(|task| is_waiting(task)).count();
+
+    lines.push(String::new());
+    lines.push(format!(
+        "Total: {} tasks ({} completed, {} active, {} waiting)",
+        tasks.len(),
+        completed,
+        active,
+        waiting
+    ));
+
+    lines.join("\n")
+}
+
+fn truncate_title(title: &str) -> String {
+    let mut chars = title.chars();
+    if title.chars().count() <= TITLE_LIMIT {
+        return title.to_string();
+    }
+
+    let truncated: String = chars.by_ref().take(TITLE_LIMIT - 3).collect();
+    format!("{truncated}...")
+}
+
+fn format_state(task: &ExecutionTask) -> String {
+    match serde_json::to_value(task.current_state)
+        .expect("task state should serialize")
+        .as_str()
+        .expect("task state should serialize as string")
+    {
+        "done" => "✅ Done".to_string(),
+        "merged" => "🔀 Merged".to_string(),
+        "implementing" => "🔧 Implementing".to_string(),
+        "pending" => "⏳ Pending".to_string(),
+        other => title_case(other),
+    }
+}
+
+fn format_risk(task: &ExecutionTask) -> String {
+    task.impact
+        .as_ref()
+        .map(|impact| {
+            serde_json::to_value(impact.risk_level)
+                .expect("impact risk should serialize")
+                .as_str()
+                .expect("impact risk should serialize as string")
+                .to_string()
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn is_completed(task: &ExecutionTask) -> bool {
+    matches!(task.current_state, TaskState::Done | TaskState::Merged)
+}
+
+fn is_active(task: &ExecutionTask) -> bool {
+    matches!(
+        task.current_state,
+        TaskState::Implementing
+            | TaskState::Analyzing
+            | TaskState::Reviewing
+            | TaskState::Deploying
+    )
+}
+
+fn is_waiting(task: &ExecutionTask) -> bool {
+    matches!(
+        task.current_state,
+        TaskState::Draft | TaskState::Pending | TaskState::Blocked | TaskState::AwaitingGithubSync
+    )
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut out = first.to_uppercase().collect::<String>();
+                    out.push_str(chars.as_str());
+                    out
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn escape_cell(value: &str) -> String {
+    value.replace('|', "\\|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::export_markdown;
+    use crate::export::ExportFilter;
+    use crate::store::{ExecutionTask, ImpactRiskLevel, TaskImpact, TaskState, TasksSnapshot};
+    use chrono::{Duration, TimeZone, Utc};
+
+    fn sample_task(
+        id: &str,
+        title: &str,
+        state: TaskState,
+        risk_level: Option<ImpactRiskLevel>,
+    ) -> ExecutionTask {
+        let created_at = Utc.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap();
+        let mut task = ExecutionTask::new(id, title);
+        task.current_state = state;
+        task.branch_name = Some(format!("branch/{id}"));
+        task.created_at = created_at;
+        task.updated_at = created_at + Duration::minutes(5);
+        task.impact = risk_level.map(|risk_level| TaskImpact {
+            risk_level,
+            affected_symbols: 1,
+            depth1: vec!["src/lib.rs".to_string()],
+            analyzed_at: created_at,
+            analyzed_commit: Some("abc123".to_string()),
+            input_hash: Some("hash".to_string()),
+        });
+        task
+    }
+
+    fn empty_snapshot() -> TasksSnapshot {
+        TasksSnapshot {
+            version: 1,
+            generated_at: Utc.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap(),
+            generated_from_event_id: Some("event-1".to_string()),
+            tasks: Vec::new(),
+            file_locks: Default::default(),
+        }
+    }
+
+    #[test]
+    fn exports_full_table() {
+        let mut snapshot = empty_snapshot();
+        snapshot.tasks = vec![
+            sample_task(
+                "task-1",
+                "Implement markdown export",
+                TaskState::Implementing,
+                Some(ImpactRiskLevel::Medium),
+            ),
+            sample_task(
+                "task-2",
+                "Merge snapshot writer",
+                TaskState::Merged,
+                Some(ImpactRiskLevel::High),
+            ),
+        ];
+
+        let markdown = export_markdown(&snapshot, None);
+
+        assert!(markdown.contains("| ID | Title | State | Risk | Branch | Created |"));
+        assert!(markdown.contains("| task-1 | Implement markdown export | 🔧 Implementing | MEDIUM | branch/task-1 | 2026-04-10 |"));
+        assert!(markdown.contains(
+            "| task-2 | Merge snapshot writer | 🔀 Merged | HIGH | branch/task-2 | 2026-04-10 |"
+        ));
+        assert!(markdown.ends_with("Total: 2 tasks (1 completed, 1 active, 0 waiting)"));
+    }
+
+    #[test]
+    fn exports_empty_snapshot() {
+        let markdown = export_markdown(&empty_snapshot(), None);
+
+        assert_eq!(
+            markdown,
+            "| ID | Title | State | Risk | Branch | Created |\n| --- | --- | --- | --- | --- | --- |\n\nTotal: 0 tasks (0 completed, 0 active, 0 waiting)"
+        );
+    }
+
+    #[test]
+    fn exports_single_task() {
+        let mut snapshot = empty_snapshot();
+        snapshot
+            .tasks
+            .push(sample_task("task-1", "Ship feature", TaskState::Done, None));
+
+        let markdown = export_markdown(&snapshot, None);
+
+        assert!(markdown
+            .contains("| task-1 | Ship feature | ✅ Done | - | branch/task-1 | 2026-04-10 |"));
+        assert!(markdown.ends_with("Total: 1 tasks (1 completed, 0 active, 0 waiting)"));
+    }
+
+    #[test]
+    fn summarizes_mixed_states() {
+        let mut snapshot = empty_snapshot();
+        snapshot.tasks = vec![
+            sample_task("done", "Done task", TaskState::Done, None),
+            sample_task("merged", "Merged task", TaskState::Merged, None),
+            sample_task("impl", "Implementing task", TaskState::Implementing, None),
+            sample_task("pending", "Pending task", TaskState::Pending, None),
+            sample_task("draft", "Draft task", TaskState::Draft, None),
+        ];
+
+        let markdown = export_markdown(&snapshot, None);
+
+        assert!(markdown.contains("| done | Done task | ✅ Done | - | branch/done | 2026-04-10 |"));
+        assert!(markdown
+            .contains("| merged | Merged task | 🔀 Merged | - | branch/merged | 2026-04-10 |"));
+        assert!(markdown.contains(
+            "| impl | Implementing task | 🔧 Implementing | - | branch/impl | 2026-04-10 |"
+        ));
+        assert!(markdown
+            .contains("| pending | Pending task | ⏳ Pending | - | branch/pending | 2026-04-10 |"));
+        assert!(markdown.contains("| draft | Draft task | Draft | - | branch/draft | 2026-04-10 |"));
+        assert!(markdown.ends_with("Total: 5 tasks (2 completed, 1 active, 2 waiting)"));
+    }
+
+    #[test]
+    fn truncates_long_titles() {
+        let mut snapshot = empty_snapshot();
+        snapshot.tasks.push(sample_task(
+            "task-1",
+            "This is an intentionally long title that should be truncated in markdown output",
+            TaskState::Pending,
+            Some(ImpactRiskLevel::Low),
+        ));
+
+        let markdown = export_markdown(&snapshot, None);
+
+        assert!(markdown.contains("This is an intentionally long title that shou..."));
+        assert!(!markdown.contains(
+            "This is an intentionally long title that should be truncated in markdown output"
+        ));
+    }
+
+    #[test]
+    fn filters_markdown_output() {
+        let mut snapshot = empty_snapshot();
+        snapshot.tasks = vec![
+            sample_task(
+                "task-1",
+                "Implement markdown export",
+                TaskState::Implementing,
+                Some(ImpactRiskLevel::Medium),
+            ),
+            sample_task(
+                "task-2",
+                "Ship release",
+                TaskState::Done,
+                Some(ImpactRiskLevel::High),
+            ),
+        ];
+
+        let markdown = export_markdown(
+            &snapshot,
+            Some(&ExportFilter {
+                state: Some("implementing".to_string()),
+                risk_level: None,
+                since: None,
+            }),
+        );
+
+        assert!(markdown.contains("| task-1 | Implement markdown export |"));
+        assert!(!markdown.contains("| task-2 | Ship release |"));
+        assert!(markdown.ends_with("Total: 1 tasks (0 completed, 1 active, 0 waiting)"));
+    }
+}

--- a/crates/mergegate-core/src/export_md.rs
+++ b/crates/mergegate-core/src/export_md.rs
@@ -40,12 +40,10 @@ pub fn export_markdown(snapshot: &TasksSnapshot, filter: Option<&ExportFilter>) 
 }
 
 fn truncate_title(title: &str) -> String {
-    let mut chars = title.chars();
     if title.chars().count() <= TITLE_LIMIT {
         return title.to_string();
     }
-
-    let truncated: String = chars.by_ref().take(TITLE_LIMIT - 3).collect();
+    let truncated: String = title.chars().take(TITLE_LIMIT - 3).collect();
     format!("{truncated}...")
 }
 

--- a/crates/mergegate-core/src/lib.rs
+++ b/crates/mergegate-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod anthropic;
 pub mod cache;
 pub mod config;
 pub mod conversation;
+pub mod dashboard;
 pub mod dag;
 pub mod dream;
 pub mod error;
@@ -63,6 +64,24 @@ pub use cache::{
 pub use config::{ApiConfig, Config, SessionConfig, ToolConfig, UiConfig};
 pub use conversation::{
     Conversation, ConversationError, ConversationManager, ConversationMessage, ConversationMetadata,
+};
+pub use dashboard::{
+    dag_response as dashboard_dag_response,
+    dispatchable_response as dashboard_dispatchable_response,
+    locks_response as dashboard_locks_response,
+    stats_response as dashboard_stats_response,
+    status_response as dashboard_status_response,
+    task_detail_response as dashboard_task_detail_response,
+    tasks_response as dashboard_tasks_response,
+    validate_response as dashboard_validate_response,
+    DashboardDagResponse,
+    DashboardDispatchableResponse,
+    DashboardLocksResponse,
+    DashboardStatsResponse,
+    DashboardStatusResponse,
+    DashboardTaskDetailResponse,
+    DashboardTasksResponse,
+    DashboardValidateResponse,
 };
 pub use error::Error;
 pub use error_policy::{CircuitBreaker, CircuitState, FallbackStrategy};

--- a/crates/mergegate-core/src/lib.rs
+++ b/crates/mergegate-core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod dag;
 pub mod dream;
 pub mod error;
 pub mod error_policy;
+pub mod export;
+pub mod export_md;
 pub mod feature_flags;
 pub mod gate;
 pub mod git;
@@ -26,12 +28,14 @@ pub mod protocol;
 pub mod retry;
 pub mod rules;
 pub mod session;
+pub mod stats;
 pub mod store;
 pub mod streaming;
 pub mod token;
 pub mod tool;
 pub mod tools;
 pub mod types;
+pub mod validate;
 pub mod workflow;
 
 pub use agent::{

--- a/crates/mergegate-core/src/stats.rs
+++ b/crates/mergegate-core/src/stats.rs
@@ -1,0 +1,333 @@
+use crate::store::{ExecutionTask, TasksSnapshot};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskStats {
+    pub total: usize,
+    pub completed: usize,
+    pub active: usize,
+    pub waiting: usize,
+    pub failed: usize,
+    pub completion_rate_pct: f64,
+    pub avg_lead_time_hours: Option<f64>,
+    pub risk_distribution: HashMap<String, usize>,
+}
+
+pub fn compute_stats(snapshot: &TasksSnapshot) -> TaskStats {
+    let total = snapshot.tasks.len();
+    let completed = snapshot
+        .tasks
+        .iter()
+        .filter(|task| is_completed(task))
+        .count();
+    let active = snapshot.tasks.iter().filter(|task| is_active(task)).count();
+    let waiting = snapshot
+        .tasks
+        .iter()
+        .filter(|task| is_waiting(task))
+        .count();
+    let failed = snapshot.tasks.iter().filter(|task| is_failed(task)).count();
+
+    let completion_rate_pct = if total == 0 {
+        0.0
+    } else {
+        (completed as f64 / total as f64) * 100.0
+    };
+
+    let completed_lead_times: Vec<f64> = snapshot
+        .tasks
+        .iter()
+        .filter(|task| is_completed(task))
+        .map(task_lead_time_hours)
+        .collect();
+
+    let avg_lead_time_hours = if completed_lead_times.is_empty() {
+        None
+    } else {
+        Some(completed_lead_times.iter().sum::<f64>() / completed_lead_times.len() as f64)
+    };
+
+    let mut risk_distribution = HashMap::from([
+        ("low".to_string(), 0usize),
+        ("medium".to_string(), 0usize),
+        ("high".to_string(), 0usize),
+        ("critical".to_string(), 0usize),
+    ]);
+
+    for task in &snapshot.tasks {
+        if let Some(impact) = &task.impact {
+            let key = match impact.risk_level {
+                crate::store::ImpactRiskLevel::Low => "low",
+                crate::store::ImpactRiskLevel::Medium => "medium",
+                crate::store::ImpactRiskLevel::High => "high",
+                crate::store::ImpactRiskLevel::Critical => "critical",
+            };
+            *risk_distribution.entry(key.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    TaskStats {
+        total,
+        completed,
+        active,
+        waiting,
+        failed,
+        completion_rate_pct,
+        avg_lead_time_hours,
+        risk_distribution,
+    }
+}
+
+fn is_completed(task: &ExecutionTask) -> bool {
+    matches!(
+        task.current_state,
+        crate::store::TaskState::Done | crate::store::TaskState::Merged
+    )
+}
+
+fn is_active(task: &ExecutionTask) -> bool {
+    matches!(
+        task.current_state,
+        crate::store::TaskState::Analyzing
+            | crate::store::TaskState::Implementing
+            | crate::store::TaskState::Reviewing
+            | crate::store::TaskState::Deploying
+    )
+}
+
+fn is_waiting(task: &ExecutionTask) -> bool {
+    matches!(
+        task.current_state,
+        crate::store::TaskState::Draft
+            | crate::store::TaskState::Pending
+            | crate::store::TaskState::Blocked
+            | crate::store::TaskState::AwaitingGithubSync
+    )
+}
+
+fn is_failed(task: &ExecutionTask) -> bool {
+    matches!(task.current_state, crate::store::TaskState::Failed)
+}
+
+fn task_lead_time_hours(task: &ExecutionTask) -> f64 {
+    hours_between(task.created_at, task.updated_at)
+}
+
+fn hours_between(start: DateTime<Utc>, end: DateTime<Utc>) -> f64 {
+    (end - start).num_seconds() as f64 / 3600.0
+}
+
+impl fmt::Display for TaskStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let avg_lead_time = self
+            .avg_lead_time_hours
+            .map(|hours| format!("{hours:.2}h"))
+            .unwrap_or_else(|| "n/a".to_string());
+
+        writeln!(f, "MergeGate Task Stats")?;
+        writeln!(f, "  Total: {}", self.total)?;
+        writeln!(
+            f,
+            "  Completed: {} ({:.1}%)",
+            self.completed, self.completion_rate_pct
+        )?;
+        writeln!(f, "  Active: {}", self.active)?;
+        writeln!(f, "  Waiting: {}", self.waiting)?;
+        writeln!(f, "  Failed: {}", self.failed)?;
+        writeln!(f, "  Avg lead time: {}", avg_lead_time)?;
+        writeln!(
+            f,
+            "  Risk: low={} medium={} high={} critical={}",
+            self.risk_distribution.get("low").copied().unwrap_or(0),
+            self.risk_distribution.get("medium").copied().unwrap_or(0),
+            self.risk_distribution.get("high").copied().unwrap_or(0),
+            self.risk_distribution.get("critical").copied().unwrap_or(0),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_stats, TaskStats};
+    use crate::store::{ExecutionTask, ImpactRiskLevel, TaskImpact, TaskState, TasksSnapshot};
+    use chrono::{Duration, TimeZone, Utc};
+
+    #[test]
+    fn empty_snapshot_returns_zeroed_stats() {
+        let stats = compute_stats(&TasksSnapshot::default());
+
+        assert_eq!(
+            stats,
+            TaskStats {
+                total: 0,
+                completed: 0,
+                active: 0,
+                waiting: 0,
+                failed: 0,
+                completion_rate_pct: 0.0,
+                avg_lead_time_hours: None,
+                risk_distribution: [
+                    ("low".to_string(), 0),
+                    ("medium".to_string(), 0),
+                    ("high".to_string(), 0),
+                    ("critical".to_string(), 0),
+                ]
+                .into_iter()
+                .collect(),
+            }
+        );
+    }
+
+    #[test]
+    fn all_done_snapshot_has_full_completion_rate() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("t1", TaskState::Done, 2, None),
+                task("t2", TaskState::Done, 4, None),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let stats = compute_stats(&snapshot);
+
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.completed, 2);
+        assert_eq!(stats.active, 0);
+        assert_eq!(stats.waiting, 0);
+        assert_eq!(stats.failed, 0);
+        assert!((stats.completion_rate_pct - 100.0).abs() < f64::EPSILON);
+        assert_eq!(stats.avg_lead_time_hours, Some(3.0));
+    }
+
+    #[test]
+    fn mixed_states_are_counted_by_bucket() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("done", TaskState::Done, 1, None),
+                task("active1", TaskState::Implementing, 1, None),
+                task("active2", TaskState::Reviewing, 1, None),
+                task("waiting1", TaskState::Pending, 1, None),
+                task("waiting2", TaskState::Blocked, 1, None),
+                task("failed", TaskState::Failed, 1, None),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let stats = compute_stats(&snapshot);
+
+        assert_eq!(stats.total, 6);
+        assert_eq!(stats.completed, 1);
+        assert_eq!(stats.active, 2);
+        assert_eq!(stats.waiting, 2);
+        assert_eq!(stats.failed, 1);
+        assert!((stats.completion_rate_pct - (100.0 / 6.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn risk_distribution_counts_each_level() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("low", TaskState::Pending, 1, Some(ImpactRiskLevel::Low)),
+                task(
+                    "medium",
+                    TaskState::Pending,
+                    1,
+                    Some(ImpactRiskLevel::Medium),
+                ),
+                task("high", TaskState::Pending, 1, Some(ImpactRiskLevel::High)),
+                task(
+                    "critical",
+                    TaskState::Pending,
+                    1,
+                    Some(ImpactRiskLevel::Critical),
+                ),
+                task("none", TaskState::Pending, 1, None),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let stats = compute_stats(&snapshot);
+
+        assert_eq!(stats.risk_distribution.get("low"), Some(&1));
+        assert_eq!(stats.risk_distribution.get("medium"), Some(&1));
+        assert_eq!(stats.risk_distribution.get("high"), Some(&1));
+        assert_eq!(stats.risk_distribution.get("critical"), Some(&1));
+    }
+
+    #[test]
+    fn average_lead_time_only_uses_completed_tasks() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("done1", TaskState::Done, 2, None),
+                task("done2", TaskState::Done, 4, None),
+                task("active", TaskState::Implementing, 20, None),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let stats = compute_stats(&snapshot);
+
+        assert_eq!(stats.avg_lead_time_hours, Some(3.0));
+    }
+
+    #[test]
+    fn merged_counts_as_completed_not_active() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![task("merged", TaskState::Merged, 2, None)],
+            ..TasksSnapshot::default()
+        };
+
+        let stats = compute_stats(&snapshot);
+
+        assert_eq!(stats.completed, 1);
+        assert_eq!(stats.active, 0);
+        assert_eq!(stats.waiting, 0);
+        assert_eq!(stats.failed, 0);
+    }
+
+    #[test]
+    fn display_includes_terminal_friendly_summary() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![task(
+                "done",
+                TaskState::Done,
+                2,
+                Some(ImpactRiskLevel::High),
+            )],
+            ..TasksSnapshot::default()
+        };
+
+        let rendered = compute_stats(&snapshot).to_string();
+
+        assert!(rendered.contains("MergeGate Task Stats"));
+        assert!(rendered.contains("Completed: 1 (100.0%)"));
+        assert!(rendered.contains("Failed: 0"));
+        assert!(rendered.contains("Avg lead time: 2.00h"));
+        assert!(rendered.contains("high=1"));
+    }
+
+    fn task(
+        id: &str,
+        state: TaskState,
+        lead_time_hours: i64,
+        risk_level: Option<ImpactRiskLevel>,
+    ) -> ExecutionTask {
+        let created_at = Utc.with_ymd_and_hms(2026, 4, 10, 0, 0, 0).unwrap();
+        let mut task = ExecutionTask::new(id, format!("Task {id}"));
+        task.current_state = state;
+        task.created_at = created_at;
+        task.updated_at = created_at + Duration::hours(lead_time_hours);
+        task.impact = risk_level.map(|risk_level| TaskImpact {
+            risk_level,
+            affected_symbols: 1,
+            depth1: vec!["symbol".to_string()],
+            analyzed_at: created_at,
+            analyzed_commit: None,
+            input_hash: None,
+        });
+        task
+    }
+}

--- a/crates/mergegate-core/src/validate.rs
+++ b/crates/mergegate-core/src/validate.rs
@@ -27,6 +27,19 @@ pub enum ValidationSeverity {
     Error,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationJsonReport {
+    pub severity: ValidationSeverity,
+    pub exit_code: i32,
+    pub issue_count: usize,
+    pub error_count: usize,
+    pub warning_count: usize,
+    pub orphaned_locks: Vec<String>,
+    pub invalid_transitions: Vec<String>,
+    pub circular_dependencies: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 pub fn validate_snapshot(snapshot: &TasksSnapshot) -> ValidationReport {
     let mut report = ValidationReport::default();
     let task_map = snapshot
@@ -165,6 +178,30 @@ impl ValidationReport {
             + self.circular_dependencies.len()
             + self.warnings.len()
     }
+
+    pub fn error_count(&self) -> usize {
+        self.orphaned_locks.len()
+            + self.invalid_transitions.len()
+            + self.circular_dependencies.len()
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.warnings.len()
+    }
+
+    pub fn to_json_report(&self) -> ValidationJsonReport {
+        ValidationJsonReport {
+            severity: self.severity(),
+            exit_code: self.exit_code(),
+            issue_count: self.issue_count(),
+            error_count: self.error_count(),
+            warning_count: self.warning_count(),
+            orphaned_locks: self.orphaned_locks.clone(),
+            invalid_transitions: self.invalid_transitions.clone(),
+            circular_dependencies: self.circular_dependencies.clone(),
+            warnings: self.warnings.clone(),
+        }
+    }
 }
 
 impl fmt::Display for ValidationReport {
@@ -176,10 +213,10 @@ impl fmt::Display for ValidationReport {
         };
 
         if self.severity() == ValidationSeverity::Clean {
-            return write!(f, "Validation: {severity} (0 issues)");
+            return write!(f, "{severity} (0 issues)");
         }
 
-        writeln!(f, "Validation: {severity} ({} issues)", self.issue_count())?;
+        writeln!(f, "{severity} ({} issues)", self.issue_count())?;
         write_section(f, "orphaned_locks", &self.orphaned_locks)?;
         write_section(f, "invalid_transitions", &self.invalid_transitions)?;
         write_section(f, "circular_dependencies", &self.circular_dependencies)?;
@@ -418,7 +455,7 @@ mod tests {
         let report = validate_snapshot(&snapshot);
 
         assert_eq!(report, ValidationReport::default());
-        assert_eq!(report.to_string(), "Validation: clean (0 issues)");
+        assert_eq!(report.to_string(), "clean (0 issues)");
     }
 
     #[test]
@@ -448,6 +485,22 @@ mod tests {
 
         assert_eq!(report.severity(), ValidationSeverity::Error);
         assert_eq!(report.exit_code(), 2);
+    }
+
+    #[test]
+    fn json_report_includes_fixed_counts() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![task("task-a", TaskState::Implementing, vec![])],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot).to_json_report();
+
+        assert_eq!(report.severity, ValidationSeverity::Error);
+        assert_eq!(report.exit_code, 2);
+        assert_eq!(report.issue_count, 1);
+        assert_eq!(report.error_count, 1);
+        assert_eq!(report.warning_count, 0);
     }
 
     fn task(id: &str, state: TaskState, dependencies: Vec<&str>) -> ExecutionTask {

--- a/crates/mergegate-core/src/validate.rs
+++ b/crates/mergegate-core/src/validate.rs
@@ -1,0 +1,408 @@
+use crate::store::{TaskState, TasksSnapshot};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationReport {
+    pub orphaned_locks: Vec<String>,
+    pub invalid_transitions: Vec<String>,
+    pub circular_dependencies: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationSeverity {
+    Clean,
+    Warning,
+    Error,
+}
+
+pub fn validate_snapshot(snapshot: &TasksSnapshot) -> ValidationReport {
+    let mut report = ValidationReport::default();
+    let task_map = snapshot
+        .tasks
+        .iter()
+        .map(|task| (task.id.as_str(), task))
+        .collect::<HashMap<_, _>>();
+
+    for (file, entry) in &snapshot.file_locks {
+        match task_map.get(entry.task_id.as_str()) {
+            None => report.orphaned_locks.push(format!(
+                "file lock '{file}' points to missing task '{}'",
+                entry.task_id
+            )),
+            Some(task) => match &task.lock {
+                None => report.orphaned_locks.push(format!(
+                    "file lock '{file}' points to task '{}' without an active lock",
+                    task.id
+                )),
+                Some(lock)
+                    if !lock
+                        .affected_files
+                        .iter()
+                        .any(|locked_file| locked_file == file) =>
+                {
+                    report.orphaned_locks.push(format!(
+                        "file lock '{file}' is not tracked by task '{}'",
+                        task.id
+                    ));
+                }
+                Some(_) => {}
+            },
+        }
+    }
+
+    for task in &snapshot.tasks {
+        if let Some(lock) = &task.lock {
+            if task.current_state != TaskState::Implementing {
+                report.invalid_transitions.push(format!(
+                    "task '{}' is {:?} but still holds a lock",
+                    task.id, task.current_state
+                ));
+            }
+
+            for file in &lock.affected_files {
+                match snapshot.file_locks.get(file) {
+                    Some(entry) if entry.task_id == task.id => {}
+                    Some(entry) => report.orphaned_locks.push(format!(
+                        "task '{}' expects lock for '{}' but ownership is '{}'",
+                        task.id, file, entry.task_id
+                    )),
+                    None => report.orphaned_locks.push(format!(
+                        "task '{}' expects lock for '{}' but file_locks is missing it",
+                        task.id, file
+                    )),
+                }
+            }
+        } else if task.current_state == TaskState::Implementing {
+            report.invalid_transitions.push(format!(
+                "task '{}' is implementing without an active lock",
+                task.id
+            ));
+        }
+
+        let unresolved_dependencies = task
+            .dependencies
+            .iter()
+            .filter_map(|dependency| match task_map.get(dependency.as_str()) {
+                Some(dep_task)
+                    if matches!(dep_task.current_state, TaskState::Done | TaskState::Merged) =>
+                {
+                    None
+                }
+                Some(_) => Some(dependency.clone()),
+                None => {
+                    report.warnings.push(format!(
+                        "task '{}' references missing dependency '{}'",
+                        task.id, dependency
+                    ));
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if !unresolved_dependencies.is_empty()
+            && matches!(
+                task.current_state,
+                TaskState::Analyzing
+                    | TaskState::Implementing
+                    | TaskState::Reviewing
+                    | TaskState::AwaitingGithubSync
+                    | TaskState::Merged
+                    | TaskState::Deploying
+                    | TaskState::Done
+            )
+        {
+            report.invalid_transitions.push(format!(
+                "task '{}' is {:?} with unresolved dependencies: {}",
+                task.id,
+                task.current_state,
+                unresolved_dependencies.join(", ")
+            ));
+        }
+    }
+
+    report.circular_dependencies = detect_circular_dependencies(snapshot);
+    report
+}
+
+impl ValidationReport {
+    pub fn severity(&self) -> ValidationSeverity {
+        if !self.orphaned_locks.is_empty()
+            || !self.invalid_transitions.is_empty()
+            || !self.circular_dependencies.is_empty()
+        {
+            ValidationSeverity::Error
+        } else if !self.warnings.is_empty() {
+            ValidationSeverity::Warning
+        } else {
+            ValidationSeverity::Clean
+        }
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        match self.severity() {
+            ValidationSeverity::Clean => 0,
+            ValidationSeverity::Warning => 1,
+            ValidationSeverity::Error => 2,
+        }
+    }
+
+    pub fn issue_count(&self) -> usize {
+        self.orphaned_locks.len()
+            + self.invalid_transitions.len()
+            + self.circular_dependencies.len()
+            + self.warnings.len()
+    }
+}
+
+impl fmt::Display for ValidationReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let severity = match self.severity() {
+            ValidationSeverity::Clean => "clean",
+            ValidationSeverity::Warning => "warning",
+            ValidationSeverity::Error => "error",
+        };
+
+        if self.severity() == ValidationSeverity::Clean {
+            return write!(f, "Validation: {severity} (0 issues)");
+        }
+
+        writeln!(f, "Validation: {severity} ({} issues)", self.issue_count())?;
+        write_section(f, "orphaned_locks", &self.orphaned_locks)?;
+        write_section(f, "invalid_transitions", &self.invalid_transitions)?;
+        write_section(f, "circular_dependencies", &self.circular_dependencies)?;
+        write_section(f, "warnings", &self.warnings)?;
+        Ok(())
+    }
+}
+
+fn write_section(f: &mut fmt::Formatter<'_>, name: &str, entries: &[String]) -> fmt::Result {
+    writeln!(f, "- {name}: {}", entries.len())?;
+    for entry in entries {
+        writeln!(f, "  - {entry}")?;
+    }
+    Ok(())
+}
+
+fn detect_circular_dependencies(snapshot: &TasksSnapshot) -> Vec<String> {
+    let graph = snapshot
+        .tasks
+        .iter()
+        .map(|task| (task.id.as_str(), task.dependencies.as_slice()))
+        .collect::<HashMap<_, _>>();
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut cycles = HashSet::new();
+    let mut path = Vec::new();
+
+    for task in &snapshot.tasks {
+        visit_dependency_path(
+            task.id.as_str(),
+            &graph,
+            &mut visiting,
+            &mut visited,
+            &mut path,
+            &mut cycles,
+        );
+    }
+
+    let mut ordered = cycles.into_iter().collect::<Vec<_>>();
+    ordered.sort();
+    ordered
+}
+
+fn visit_dependency_path(
+    task_id: &str,
+    graph: &HashMap<&str, &[String]>,
+    visiting: &mut HashSet<String>,
+    visited: &mut HashSet<String>,
+    path: &mut Vec<String>,
+    cycles: &mut HashSet<String>,
+) {
+    if visited.contains(task_id) {
+        return;
+    }
+
+    let inserted = visiting.insert(task_id.to_string());
+    if inserted {
+        path.push(task_id.to_string());
+    }
+
+    if let Some(dependencies) = graph.get(task_id) {
+        for dependency in *dependencies {
+            if let Some(cycle_start) = path.iter().position(|node| node == dependency) {
+                let mut cycle = path[cycle_start..].to_vec();
+                cycle.push(dependency.clone());
+                cycles.insert(cycle.join(" -> "));
+                continue;
+            }
+
+            if graph.contains_key(dependency.as_str()) {
+                visit_dependency_path(dependency, graph, visiting, visited, path, cycles);
+            }
+        }
+    }
+
+    if inserted {
+        visiting.remove(task_id);
+        visited.insert(task_id.to_string());
+        path.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_snapshot, ValidationReport, ValidationSeverity};
+    use crate::store::{ExecutionTask, FileLockEntry, TaskLockSnapshot, TaskState, TasksSnapshot};
+    use chrono::{Duration, Utc};
+    use std::collections::HashMap;
+
+    #[test]
+    fn clean_snapshot() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("task-a", TaskState::Done, vec![]),
+                task("task-b", TaskState::Pending, vec!["task-a"]),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report, ValidationReport::default());
+    }
+
+    #[test]
+    fn orphaned_lock() {
+        let mut snapshot = TasksSnapshot::default();
+        snapshot.file_locks.insert(
+            "src/lib.rs".into(),
+            FileLockEntry {
+                task_id: "missing-task".into(),
+                agent: "codex".into(),
+                node: "macbook".into(),
+                expires_at: Utc::now() + Duration::seconds(60),
+            },
+        );
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report.orphaned_locks.len(), 1);
+        assert!(report.orphaned_locks[0].contains("missing-task"));
+    }
+
+    #[test]
+    fn invalid_transition() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![task("task-a", TaskState::Implementing, vec![])],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report.invalid_transitions.len(), 1);
+        assert!(report.invalid_transitions[0].contains("without an active lock"));
+    }
+
+    #[test]
+    fn circular_dependency() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("task-a", TaskState::Pending, vec!["task-b"]),
+                task("task-b", TaskState::Pending, vec!["task-a"]),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report.circular_dependencies.len(), 1);
+        assert!(report.circular_dependencies[0].contains("task-a -> task-b -> task-a"));
+    }
+
+    #[test]
+    fn multiple_issues() {
+        let mut locked_task = task("task-a", TaskState::Reviewing, vec!["task-b"]);
+        locked_task.lock = Some(task_lock(&["src/main.rs"]));
+
+        let snapshot = TasksSnapshot {
+            tasks: vec![locked_task, task("task-b", TaskState::Pending, vec![])],
+            file_locks: HashMap::from([(
+                "src/main.rs".into(),
+                FileLockEntry {
+                    task_id: "task-c".into(),
+                    agent: "codex".into(),
+                    node: "macbook".into(),
+                    expires_at: Utc::now() + Duration::seconds(60),
+                },
+            )]),
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert!(!report.orphaned_locks.is_empty());
+        assert!(!report.invalid_transitions.is_empty());
+        assert!(report.circular_dependencies.is_empty());
+    }
+
+    #[test]
+    fn empty_snapshot() {
+        let snapshot = TasksSnapshot::default();
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report, ValidationReport::default());
+        assert_eq!(report.to_string(), "Validation: clean (0 issues)");
+    }
+
+    #[test]
+    fn warnings_only_are_reported() {
+        let mut task = task("task-a", TaskState::Pending, vec!["missing"]);
+        task.dependencies = vec!["missing".to_string()];
+        let snapshot = TasksSnapshot {
+            tasks: vec![task],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report.severity(), ValidationSeverity::Warning);
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.warnings.len(), 1);
+    }
+
+    #[test]
+    fn invalid_transitions_are_errors() {
+        let snapshot = TasksSnapshot {
+            tasks: vec![task("task-a", TaskState::Implementing, vec![])],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert_eq!(report.severity(), ValidationSeverity::Error);
+        assert_eq!(report.exit_code(), 2);
+    }
+
+    fn task(id: &str, state: TaskState, dependencies: Vec<&str>) -> ExecutionTask {
+        let mut task = ExecutionTask::new(id, id);
+        task.current_state = state;
+        task.dependencies = dependencies.into_iter().map(str::to_string).collect();
+        task
+    }
+
+    fn task_lock(files: &[&str]) -> TaskLockSnapshot {
+        let now = Utc::now();
+        TaskLockSnapshot {
+            locked_by: "codex@macbook".into(),
+            locked_at: now,
+            lease_duration_sec: 60,
+            last_heartbeat: now,
+            affected_files: files.iter().map(|file| (*file).to_string()).collect(),
+        }
+    }
+}

--- a/crates/mergegate-core/src/validate.rs
+++ b/crates/mergegate-core/src/validate.rs
@@ -3,6 +3,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
+fn state_str(state: TaskState) -> String {
+    serde_json::to_value(state)
+        .expect("failed to serialize TaskState to JSON value")
+        .as_str()
+        .expect("TaskState serialized to a non-string JSON value")
+        .to_owned()
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ValidationReport {
     pub orphaned_locks: Vec<String>,
@@ -58,8 +66,9 @@ pub fn validate_snapshot(snapshot: &TasksSnapshot) -> ValidationReport {
         if let Some(lock) = &task.lock {
             if task.current_state != TaskState::Implementing {
                 report.invalid_transitions.push(format!(
-                    "task '{}' is {:?} but still holds a lock",
-                    task.id, task.current_state
+                    "task '{}' is {} but still holds a lock",
+                    task.id,
+                    state_str(task.current_state)
                 ));
             }
 
@@ -116,9 +125,9 @@ pub fn validate_snapshot(snapshot: &TasksSnapshot) -> ValidationReport {
             )
         {
             report.invalid_transitions.push(format!(
-                "task '{}' is {:?} with unresolved dependencies: {}",
+                "task '{}' is {} with unresolved dependencies: {}",
                 task.id,
-                task.current_state,
+                state_str(task.current_state),
                 unresolved_dependencies.join(", ")
             ));
         }
@@ -306,6 +315,59 @@ mod tests {
         assert_eq!(report.invalid_transitions.len(), 1);
         assert!(report.invalid_transitions[0].contains("without an active lock"));
     }
+
+    #[test]
+    fn invalid_transition_message_uses_serialised_state_name() {
+        // State messages must use snake_case (serialised form), not {:?} Debug output.
+        let snapshot = TasksSnapshot {
+            tasks: vec![task("task-a", TaskState::Implementing, vec![])],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        assert!(
+            report.invalid_transitions[0].contains("implementing"),
+            "expected 'implementing' (snake_case), got: {}",
+            report.invalid_transitions[0]
+        );
+        assert!(
+            !report.invalid_transitions[0].contains("Implementing"),
+            "message must not use Debug (PascalCase) formatting"
+        );
+    }
+
+    #[test]
+    fn dependency_transition_message_uses_serialised_state_name() {
+        // The "unresolved dependencies" path (line ~128) must also use snake_case.
+        // task-b is Pending (unresolved), and task-a is Implementing which is an
+        // active state → triggers the unresolved-dependencies invalid_transition message.
+        let snapshot = TasksSnapshot {
+            tasks: vec![
+                task("task-a", TaskState::Implementing, vec!["task-b"]),
+                task("task-b", TaskState::Pending, vec![]),
+            ],
+            ..TasksSnapshot::default()
+        };
+
+        let report = validate_snapshot(&snapshot);
+
+        let dep_msg = report
+            .invalid_transitions
+            .iter()
+            .find(|msg| msg.contains("unresolved dependencies"))
+            .expect("expected an unresolved-dependencies message");
+
+        assert!(
+            dep_msg.contains("implementing"),
+            "expected 'implementing' (snake_case), got: {dep_msg}"
+        );
+        assert!(
+            !dep_msg.contains("Implementing"),
+            "message must not use Debug (PascalCase) formatting"
+        );
+    }
+
 
     #[test]
     fn circular_dependency() {

--- a/docs/PRODUCT_DIRECTION.md
+++ b/docs/PRODUCT_DIRECTION.md
@@ -1,0 +1,123 @@
+# Product Direction — MergeGate
+
+_Last Updated: 2026-04-12_
+
+## Core Definition
+
+MergeGate is a **Rust-first deterministic execution protocol product**.
+
+Its core value is not chat, a built-in agent runtime, or a general-purpose PM dashboard.
+Its core value is a durable execution gate that can:
+
+- register work
+- record impact
+- lock files
+- decide what is dispatchable
+- attach branch / PR / merge evidence to execution
+- validate and audit the ledger
+
+The source of truth for this product is:
+
+- Rust core types and protocol behavior
+- `mergegate gate ...` CLI
+- MergeGate API surfaces exposed by `mergegate gate serve`
+
+## What MergeGate Is
+
+MergeGate is the product that answers:
+
+- what can safely start now
+- what is blocked
+- which files are owned
+- what evidence is attached to the task
+- whether the ledger is internally consistent
+
+The durable surface is:
+
+- `gate CLI`
+- `ledger`
+- `validate`
+- `dispatchable`
+- `lock`
+- `dag`
+- `stats`
+- `audit/export`
+
+## What MergeGate Is Not
+
+MergeGate is **not** the product center for:
+
+- a built-in TUI runtime
+- a built-in chat runtime
+- a vendor-specific coding agent
+- a cross-source PM dashboard
+- portfolio or organization-wide operations analytics
+
+Those surfaces may exist around MergeGate, but they are not the main product.
+
+## UI Policy
+
+UI is important, but it is a **supporting surface** for the protocol.
+
+The official MergeGate UI should:
+
+- visualize MergeGate-native concepts first
+- use Rust/API results as the single source of truth
+- minimize frontend-only business logic
+- help operators decide what to dispatch, unblock, validate, and review
+
+The official first-class UI surfaces are:
+
+- Gate Overview
+- Task Ledger
+- Dependency Map
+
+`Project Flow` and wider PM rollups are secondary and should not redefine the product.
+
+## PM Dashboard Boundary
+
+PM dashboard assets are valuable, but only some belong inside MergeGate.
+
+Safe to absorb:
+
+- information architecture such as `dispatchable first`, `alerts first`, and `dependency pressure`
+- visual patterns and reusable UI components
+- task triage and DAG presentation ideas
+
+Do not absorb into MergeGate core product definition:
+
+- multi-source federation across `personal / maestro / openclaw / github / skillbus`
+- `UnifiedTask` as the product-wide task model
+- Next.js server runtime as a runtime requirement
+- portfolio-first or PM-first positioning
+
+Cross-source orchestration belongs in a higher-level PM dashboard or ops cockpit, where MergeGate is one input among others.
+
+## Architecture Boundary
+
+MergeGate:
+
+- gate engine
+- ledger
+- CLI
+- API
+- dedicated MergeGate UI
+
+Higher-level PM dashboard:
+
+- cross-source orchestration
+- portfolio views
+- organization or personal ops analytics
+- source federation and comparison
+
+The two layers should cooperate, but they should not be collapsed into one product.
+
+## Decision Rule
+
+When evaluating roadmap items, use this filter:
+
+1. Does this make the Rust protocol stronger, safer, or easier to operate?
+2. Does this improve a MergeGate-native UI surface without changing the product boundary?
+3. If not, should it live in the higher-level PM dashboard instead?
+
+If a proposal does not strengthen MergeGate as a protocol product, it should not become part of the mainline by default.

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -11,6 +11,7 @@
 ### 1.1 Product Vision
 AIコーディングエージェントの前段に置く、engine-agnostic な gate CLI を提供する。
 現在の製品中心は TUI ではなく `mergegate gate ...` であり、ledger の記録・検証・可視化を最優先に進める。
+本流方針として、MergeGate は Rust-first の deterministic execution protocol product として進め、cross-source PM dashboard 化は本体スコープに含めない。
 
 ### 1.2 Target Users
 - ソフトウェア開発者
@@ -34,7 +35,14 @@ AIコーディングエージェントの前段に置く、engine-agnostic な g
 - `mergegate gate stats`
 - `mergegate gate serve`
 
+直近の固定契約:
+
+- `mergegate gate validate` は text 先頭に `clean` / `warning` / `error` を出し、JSON では severity / exit_code / issue_count を返す
+- `mergegate gate export-json` と `mergegate gate export-md` は共通 filter `--state` / `--risk` / `--since` を使う
+- dashboard は `/api/tasks` `/api/stats` `/api/validate` を使い、CLI と同じ ledger 定義を表示する
+
 TUI / built-in chat runtime / vendor-specific execution機能は将来拡張であり、現段階では必須スコープではない。
+また、portfolio / cross-source orchestration / PM cockpit は上位レイヤーとして扱い、MergeGate 本体の定義には含めない。
 
 ---
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -2,14 +2,15 @@
 
 **Version**: 1.0.0
 **Status**: Draft
-**Last Updated**: 2025-11-22
+**Last Updated**: 2026-04-12
 
 ---
 
 ## 1. Executive Summary
 
 ### 1.1 Product Vision
-OpenAI Codex CLIと同等の機能を持ち、Miyabiの拡張機能を統合した次世代AI開発CLIツール
+AIコーディングエージェントの前段に置く、engine-agnostic な gate CLI を提供する。
+現在の製品中心は TUI ではなく `mergegate gate ...` であり、ledger の記録・検証・可視化を最優先に進める。
 
 ### 1.2 Target Users
 - ソフトウェア開発者
@@ -18,13 +19,28 @@ OpenAI Codex CLIと同等の機能を持ち、Miyabiの拡張機能を統合し�
 
 ### 1.3 Core Value Proposition
 - **高速**: Rust実装による100ms以下の起動時間
-- **美しい**: Ratatui TUIによるリッチなターミナル体験
-- **自律的**: 完全自律型タスク実行
-- **拡張性**: プラグイン対応
+- **安全**: lock / impact / merge evidence を明示的に記録
+- **監査可能**: validate / export / stats / dashboard で ledger を点検できる
+- **拡張性**: OpenClaw や外部自動化へ JSON 出力で接続できる
+
+### 1.4 Current Product Surface
+
+現在の安定インターフェースは以下:
+
+- `mergegate gate status`
+- `mergegate gate validate`
+- `mergegate gate export-json`
+- `mergegate gate export-md`
+- `mergegate gate stats`
+- `mergegate gate serve`
+
+TUI / built-in chat runtime / vendor-specific execution機能は将来拡張であり、現段階では必須スコープではない。
 
 ---
 
 ## 2. Functional Requirements
+
+> Note: 以下の TUI/LLM 要件は将来ロードマップとして保持している。直近開発の primary surface は gate CLI と web dashboard である。
 
 ### 2.1 TUI System
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -114,6 +114,30 @@ cargo build --release
 | `mergegate gate locks` | active lock を表示 |
 | `mergegate gate dispatchable` | 今着手できる task を表示 |
 | `mergegate gate dag` | 依存順序を表示 |
+| `mergegate gate serve` | MergeGate-native web surface を表示 |
+
+## Web Surface
+
+`mergegate gate serve` でローカル dashboard を起動できます。
+
+```bash
+./target/release/mergegate gate serve
+./target/release/mergegate gate serve --port 8080
+```
+
+この UI は次の 3 面で構成されます。
+
+- Gate Overview: validation severity、next actions、ready / attention / progress queue
+- Task Ledger: `state` `risk` `since` filter と task detail drill-in
+- Dependency Map: DAG level、blocked chain、dispatchable frontier の可視化
+
+静的アセットの探索順は次の通りです。
+
+1. `MERGEGATE_DASHBOARD_STATIC_DIR`
+2. `web/dashboard/dist`
+3. 内蔵 dashboard fallback
+
+内蔵 UI でも API は Rust-owned contract をそのまま表示します。frontend 独自の task state は持ちません。
 
 ## 実行エンジンとの関係
 

--- a/docs/dtp/NEXT-STEPS.md
+++ b/docs/dtp/NEXT-STEPS.md
@@ -1,54 +1,23 @@
-# Next Steps — Gate 可視化・検証機能の完成
+# Next Steps — 次フェーズ
 
 _Updated: 2026-04-12_
 
 ---
 
-## 直近の完了条件
+監査面の v1 は完了した前提で、ここからは外部連携と品質ゲートを広げる。
+現在の固定済み基盤は以下:
 
-Gate CLI を「ledger を読める・監査できる・運用に載せられる」状態まで引き上げる。
+- `mergegate gate validate` の text / JSON / exit code 契約
+- `export-json` / `export-md` の共通 filter 契約
+- `stats --format json` の固定分類
+- dashboard の `/api/tasks` `/api/stats` `/api/validate`
+- README / product spec の CLI-first 同期
 
-完了条件:
+本流方針:
 
-- `mergegate gate validate` が snapshot 整合性を検査できる
-- `mergegate gate export-json` / `export-md` が同じ filter 仕様を持つ
-- `mergegate gate stats --format json` のスキーマが固定される
-- dashboard が `/api/tasks` / `/api/stats` / `/api/validate` を使って CLI と同じ定義で表示する
-- README のコマンド例が現行実装と一致する
-
----
-
-## 今週
-
-### 1. Validation を正式公開
-
-- `gate validate` を追加
-- text 出力で `clean` / `warning` / `error` を先頭表示
-- JSON 出力を OpenClaw 連携向けに固定
-- 終了コードを定義
-  - `0`: clean
-  - `1`: warnings only
-  - `2`: consistency error
-
-### 2. Export / Stats の統一
-
-- `export-json` に `--state` / `--risk` / `--since`
-- `export-md` に同一 filter を追加
-- `stats` に `failed` を追加し、completed / active / waiting の分類を固定
-- CLI と dashboard が同一集計ロジックを使うようにする
-
-### 3. Dashboard API の整備
-
-- `/api/tasks`
-- `/api/stats`
-- `/api/validate`
-- 既存 `/api/status` は後方互換のため維持してもよいが、UI は新APIを優先利用する
-
-### 4. テストとドキュメント同期
-
-- `cargo test --all`
-- README の使用例を更新
-- `docs/PRODUCT_SPEC.md` の先頭を CLI-first に修正
+- MergeGate は Rust-first protocol product として進める
+- cross-source PM dashboard 化は本体スコープに含めない
+- UI は MergeGate-native surface に限定して強化する
 
 ---
 

--- a/docs/dtp/NEXT-STEPS.md
+++ b/docs/dtp/NEXT-STEPS.md
@@ -1,139 +1,73 @@
-# Next Steps — DTP 実装後のロードマップ
+# Next Steps — Gate 可視化・検証機能の完成
 
-_Phase A/B 完了時点での計画。clippy 修正 + Phase C 完了後に更新。_
-
----
-
-## 直近（今日〜明日）
-
-### 1. clippy 修正 → Phase C 完了
-
-```
-clippy 7件修正 (10分) → Phase C: GitHub Evidence + E2E (10分)
-合計: 20分
-```
-
-Phase C でやること:
-- github.rs の既存 `get_pull_request()` を使って merge 証跡取得
-- protocol.rs に `verify_merge()` 追加
-- escape hatch: `force_unlock`, `manual_complete`
-- E2E テスト: register → ... → done
-
-### 2. rust-ai-pipeline 品質ゲート統合
-
-`ai-pipeline phase1` を DTP の GATE 4.5 として組み込む:
-- `miyabi gate assign` 後に `ai-pipeline phase1 --project . --format json` を実行
-- `all_passed == false` なら implementing に留まる
-- `failure_kind` を tasks.json に記録
-
-### 3. GNI 再インデックス + 最終インパクト確認
-
-Phase C 完了後に `npx gitnexus analyze --force` して全体の影響を最終確認。
+_Updated: 2026-04-12_
 
 ---
 
-## 短期（今週）
+## 直近の完了条件
 
-### 4. OpenClaw ドッキング実装
+Gate CLI を「ledger を読める・監査できる・運用に載せられる」状態まで引き上げる。
 
-`docs/dtp/OPENCLAW-DOCKING-PLAN.md` に基づく:
+完了条件:
 
-| # | 項目 | 工数 |
-|---|------|------|
-| 4a | `miyabi gate` の JSON 出力を OpenClaw hooks でキャッチ | 30分 |
-| 4b | OpenClaw main が `miyabi gate dispatchable` でタスク取得 | 30分 |
-| 4c | `sessions spawn` でサブエージェントに配布 | 30分 |
-| 4d | `project_memory/tasks.json` を memory sync 対象に追加 | 15分 |
-| 4e | E2E: OpenClaw main → miyabi gate → カエデ実装 → サクラレビュー → merge | 1時間 |
-
-### 5. Maestro Playbook 登録
-
-Phase A/B/C の autorun を Maestro Auto Run 形式に変換:
-- チェックボックス形式のマークダウン
-- Maestro GUI から実行可能に
-- Session Isolation + Worktree Support 有効化
-
-### 6. miyabi CLI (npm) との統合
-
-`npx miyabi` (TypeScript版) と `miyabi` (Rust版) の共存:
-- `npx miyabi bus` → 既存のキュー管理
-- `miyabi gate` → DTP のGATE管理
-- 将来的に `npx miyabi` の `task` と `bus` を Rust 版に移行
+- `mergegate gate validate` が snapshot 整合性を検査できる
+- `mergegate gate export-json` / `export-md` が同じ filter 仕様を持つ
+- `mergegate gate stats --format json` のスキーマが固定される
+- dashboard が `/api/tasks` / `/api/stats` / `/api/validate` を使って CLI と同じ定義で表示する
+- README のコマンド例が現行実装と一致する
 
 ---
 
-## 中期（今月）
+## 今週
 
-### 7. Heartbeat デーモン化
+### 1. Validation を正式公開
 
-- `miyabi gate heartbeat <task-id>` を cron で定期実行
-- launchd plist で Mac 起動時に自動スタート
-- lease 300秒 / heartbeat 60秒 / stale 2回ミスで解放
+- `gate validate` を追加
+- text 出力で `clean` / `warning` / `error` を先頭表示
+- JSON 出力を OpenClaw 連携向けに固定
+- 終了コードを定義
+  - `0`: clean
+  - `1`: warnings only
+  - `2`: consistency error
 
-### 8. tasks.json の git push 自動同期
+### 2. Export / Stats の統一
 
-- Phase 完了時に自動 `git add project_memory/tasks.json && git commit && git push`
-- 他ノードで `git pull` → tasks.json 更新 → ロック状態が共有される
-- 衝突時は CAS version で検出
+- `export-json` に `--state` / `--risk` / `--since`
+- `export-md` に同一 filter を追加
+- `stats` に `failed` を追加し、completed / active / waiting の分類を固定
+- CLI と dashboard が同一集計ロジックを使うようにする
 
-### 9. Telegram 通知統合
+### 3. Dashboard API の整備
 
-- GATE 通過/拒否を Telegram に通知
-- HIGH/CRITICAL の人間承認を Telegram ボタンで
-- Phase 完了報告を Telegram + VOICEBOX 両方に
+- `/api/tasks`
+- `/api/stats`
+- `/api/validate`
+- 既存 `/api/status` は後方互換のため維持してもよいが、UI は新APIを優先利用する
 
-### 10. GitHub Actions CI 追加（任意）
+### 4. テストとドキュメント同期
 
-現在はローカル完結だが、PR レビュー時の自動チェックとして:
-- `cargo test + cargo clippy` を GitHub Actions で実行
-- 品質ゲートは Rust コンパイラが担保するので CI は補助
-
----
-
-## 長期（来月以降）
-
-### 11. rust-ai-pipeline Phase 2〜5 統合
-
-品質ゲートの多層化:
-- Phase 2: マルチエージェント分離（テスト作成者 ≠ 実装者）
-- Phase 3: Miri / Verus / Kani（静的検証）
-- Phase 4: proptest + cargo-fuzz（動的検証）
-- Phase 5: cargo-mutants（メタ検証）
-
-### 12. miyabi-private (TypeScript) からの完全移行
-
-miyabi-private の task-manager (TypeScript) → miyabi-core (Rust) への段階的移行:
-- BidirectionalSync → Rust 再実装
-- GitHub Label Sync → github.rs に統合
-- Projects V2 Sync → github_tools.rs に統合
-
-### 13. OpenClaw Framework 公開
-
-DTP を OpenClaw のプラグインとして公開:
-- `openclaw plugin install miyabi-dtp`
-- 任意の OpenClaw 環境で使える確定的タスク実行基盤
-- ドキュメント: how-to-dock-dtp-with-openclaw.md
+- `cargo test --all`
+- README の使用例を更新
+- `docs/PRODUCT_SPEC.md` の先頭を CLI-first に修正
 
 ---
 
-## 優先度マトリックス
+## 次フェーズ
 
-```
-          緊急
-           │
-     ┌─────┼─────┐
-     │  1  │  4  │
-重要 ─  C+  │  OC │ ← 今週
-     │clippy│dock │
-     ├─────┼─────┤
-     │  7  │  10 │
-     │heart│  CI │ ← 来週以降
-     │beat │     │
-     └─────┼─────┘
-           │
-         非緊急
-```
+### OpenClaw ドッキング
 
----
+- `dispatchable` と `validate` を使って外部オーケストレータ接続
+- heartbeat / lock 状態を OpenClaw 側で監視
+- `project_memory/tasks.json` を execution mirror として配布
 
-_Phase C 完了後に再評価して優先度を更新する。_
+### 品質ゲートの多層化
+
+- `ai-pipeline phase1` 統合
+- 追加の静的検証・動的検証
+- GitHub Actions で補助チェック
+
+### 配布・公開面の強化
+
+- guide と docs を一本化
+- dashboard の利用例を追加
+- export 出力を外部ツールから読みやすい形に磨く


### PR DESCRIPTION
## Summary
- add gate validation, export, and stats surfaces for ledger auditing
- unify validate JSON schema with the dashboard API and add machine-readable stats/export filters
- redesign the local dashboard into MergeGate-native Gate Overview, Task Ledger, and Dependency Map surfaces
- fix direct route restoration for `/ledger` and `/dependency`, and keep task detail synced with active ledger filters

## Testing
- cargo test --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run --quiet --bin mergegate -- gate validate
- cargo run --quiet --bin mergegate -- gate --format json stats